### PR TITLE
feat(card): allow due_soon_days: 0 for today-only scope

### DIFF
--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -137,8 +137,6 @@ const _TRANSLATIONS = {
     ed_preset_assignees_placeholder: "e.g. person.ben, person.anna",
     ed_preset_labels: "Labels (comma-separated)",
     ed_preset_labels_placeholder: "e.g. School, Morning Routine",
-    ed_show_only_due_today: "Due today only",
-    ed_show_only_due_today_include_overdue: "Include overdue",
   },
   nl: {
     my_tasks: "Mijn taken",
@@ -1074,8 +1072,6 @@ const _TRANSLATIONS = {
     ed_preset_assignees_placeholder: "z.B. person.ben, person.anna",
     ed_preset_labels: "Labels (kommagetrennt)",
     ed_preset_labels_placeholder: "z.B. Schule, Morgenroutine",
-    ed_show_only_due_today: "Nur heute fällig",
-    ed_show_only_due_today_include_overdue: "Überfällige einschließen",
   },
 };
 
@@ -1947,13 +1943,6 @@ class HomeTasksCard extends HTMLElement {
     if (preLabels && preLabels.length > 0) {
       const set = new Set(preLabels);
       tasks = tasks.filter((t) => t.tags && t.tags.some((tag) => set.has(tag)));
-    }
-    if (col.show_only_due_today === true) {
-      const includeOverdue = col.show_only_due_today_include_overdue === true;
-      tasks = tasks.filter((t) =>
-        this._isDueDateToday(t.due_date) ||
-        (includeOverdue && this._isDueDateOverdue(t.due_date))
-      );
     }
     return tasks;
   }
@@ -6365,22 +6354,22 @@ class HomeTasksCardEditor extends HTMLElement {
         ]),
         ...(col.show_due_soon_filter === true ? [(() => {
           const daysInput = this._el("input", { type: "number", value: col.due_soon_days ?? 7 });
-          daysInput.min = 1;
+          daysInput.min = 0;
           daysInput.max = 90;
           daysInput.addEventListener("change", () => {
-            const v = Math.max(1, Math.min(90, parseInt(daysInput.value) || 7));
+            const v = Math.max(0, Math.min(90, parseInt(daysInput.value, 10) ?? 7));
             daysInput.value = v;
             updateCol({ due_soon_days: v });
           });
           const spinUp = this._el("button", { className: "spin-btn spin-up", textContent: "\u25b4", type: "button" });
           const spinDown = this._el("button", { className: "spin-btn spin-down", textContent: "\u25be", type: "button" });
           spinUp.addEventListener("click", () => {
-            const v = Math.min(90, (parseInt(daysInput.value) || 7) + 1);
+            const v = Math.min(90, (parseInt(daysInput.value, 10) ?? 7) + 1);
             daysInput.value = v;
             daysInput.dispatchEvent(new Event("change"));
           });
           spinDown.addEventListener("click", () => {
-            const v = Math.max(1, (parseInt(daysInput.value) || 7) - 1);
+            const v = Math.max(0, (parseInt(daysInput.value, 10) ?? 7) - 1);
             daysInput.value = v;
             daysInput.dispatchEvent(new Event("change"));
           });
@@ -6388,29 +6377,6 @@ class HomeTasksCardEditor extends HTMLElement {
             daysInput,
             this._el("span", { textContent: this._t("ed_due_soon_days") }),
             this._el("div", { className: "spin-btns" }, [spinUp, spinDown]),
-          ]);
-        })()] : []),
-        (() => {
-          const sw = document.createElement("ha-switch");
-          sw.checked = col.show_only_due_today === true;
-          sw.setAttribute("aria-label", this._t("ed_show_only_due_today"));
-          sw.addEventListener("change", () => {
-            updateCol({ show_only_due_today: sw.checked });
-            this._render();
-          });
-          return this._el("div", { className: "toggle-row" }, [
-            this._el("span", { className: "toggle-label", textContent: this._t("ed_show_only_due_today") }),
-            sw,
-          ]);
-        })(),
-        ...(col.show_only_due_today === true ? [(() => {
-          const sw = document.createElement("ha-switch");
-          sw.checked = col.show_only_due_today_include_overdue === true;
-          sw.setAttribute("aria-label", this._t("ed_show_only_due_today_include_overdue"));
-          sw.addEventListener("change", () => updateCol({ show_only_due_today_include_overdue: sw.checked }));
-          return this._el("div", { className: "toggle-row" }, [
-            this._el("span", { className: "toggle-label", textContent: this._t("ed_show_only_due_today_include_overdue") }),
-            sw,
           ]);
         })()] : []),
         this._el("div", { className: "field" }, [filterLabel, filterSelect]),

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -132,6 +132,11 @@ const _TRANSLATIONS = {
     ed_move_up: "Move up",
     ed_move_down: "Move down",
     confirm_delete_section: "Delete this section? Tasks inside will become unsorted.",
+    ed_sec_preset_filters: "Preset Filters",
+    ed_preset_assignees: "Assignees (comma-separated entity IDs)",
+    ed_preset_assignees_placeholder: "e.g. person.ben, person.anna",
+    ed_preset_labels: "Labels (comma-separated)",
+    ed_preset_labels_placeholder: "e.g. School, Morning Routine",
   },
   nl: {
     my_tasks: "Mijn taken",
@@ -1062,6 +1067,11 @@ const _TRANSLATIONS = {
     ed_move_up: "Nach oben",
     ed_move_down: "Nach unten",
     confirm_delete_section: "Diesen Bereich wirklich löschen? Enthaltene Aufgaben werden unsortiert.",
+    ed_sec_preset_filters: "Voreingestellte Filter",
+    ed_preset_assignees: "Personen (kommagetrennte Entity-IDs)",
+    ed_preset_assignees_placeholder: "z.B. person.ben, person.anna",
+    ed_preset_labels: "Labels (kommagetrennt)",
+    ed_preset_labels_placeholder: "z.B. Schule, Morgenroutine",
   },
 };
 
@@ -1920,27 +1930,45 @@ class HomeTasksCard extends HTMLElement {
 
   // --- Filter & Sort ---
 
+  _preFilteredTasks(colIdx) {
+    const cs = this._columns[colIdx];
+    const col = this._config.columns[colIdx];
+    let tasks = cs.tasks;
+    const preAssignees = col.filters?.assignees;
+    const preLabels = col.filters?.labels;
+    if (preAssignees && preAssignees.length > 0) {
+      const set = new Set(preAssignees);
+      tasks = tasks.filter((t) => set.has(t.assigned_person));
+    }
+    if (preLabels && preLabels.length > 0) {
+      const set = new Set(preLabels);
+      tasks = tasks.filter((t) => t.tags && t.tags.some((tag) => set.has(tag)));
+    }
+    return tasks;
+  }
+
   _filteredTasks(colIdx) {
     const cs = this._columns[colIdx];
+    const baseTasks = this._preFilteredTasks(colIdx);
     let tasks;
     switch (cs.filter) {
       case "open":
-        tasks = cs.tasks.filter((t) => !t.completed);
+        tasks = baseTasks.filter((t) => !t.completed);
         break;
       case "done":
-        tasks = cs.tasks.filter((t) => t.completed);
+        tasks = baseTasks.filter((t) => t.completed);
         break;
       case "due_soon": {
         const col = this._config.columns[colIdx];
         const days = col.due_soon_days ?? 7;
-        tasks = cs.tasks.filter((t) =>
+        tasks = baseTasks.filter((t) =>
           !t.completed && t.due_date &&
           (this._isDueDateOverdue(t.due_date) || this._isDueDateWithinDays(t.due_date, days))
         );
         break;
       }
       default:
-        tasks = cs.tasks;
+        tasks = baseTasks;
     }
     if (cs.tagFilters.size > 0) {
       tasks = tasks.filter((t) => t.tags && t.tags.some((tag) => cs.tagFilters.has(tag)));
@@ -2475,9 +2503,12 @@ class HomeTasksCard extends HTMLElement {
   _buildColumnTagChips(col, cs, colIdx) {
     if (col.show_tags === false) return null;
     const allTags = new Set();
-    for (const t of cs.tasks) {
+    const baseTasks = this._preFilteredTasks(colIdx);
+    for (const t of baseTasks) {
       for (const tag of (t.tags || [])) allTags.add(tag);
     }
+    // Remove preset labels — they are always applied and cannot be toggled by the user
+    for (const label of (col.filters?.labels || [])) allTags.delete(label);
     if (allTags.size === 0) return null;
     const chipChildren = [];
     for (const tag of [...allTags].sort()) {
@@ -2517,9 +2548,12 @@ class HomeTasksCard extends HTMLElement {
   _buildColumnPersonChips(col, cs, colIdx) {
     if (col.show_assigned_person === false) return null;
     const assignedPersons = new Set();
-    for (const t of cs.tasks) {
+    const baseTasks = this._preFilteredTasks(colIdx);
+    for (const t of baseTasks) {
       if (t.assigned_person) assignedPersons.add(t.assigned_person);
     }
+    // Remove preset assignees — they are always applied and cannot be toggled by the user
+    for (const eid of (col.filters?.assignees || [])) assignedPersons.delete(eid);
     if (assignedPersons.size === 0) return null;
     const chipChildren = [];
     for (const eid of [...assignedPersons].sort()) {
@@ -6359,6 +6393,42 @@ class HomeTasksCardEditor extends HTMLElement {
           makeToggle("show-reminders", "ed_show_reminders", "show_reminders", true),
           makeToggle("show-recurrence", "ed_show_recurrence", "show_recurrence", true),
         ]),
+      ], false),
+      makeSection("preset-filters", "mdi:filter-settings", "ed_sec_preset_filters", [
+        (() => {
+          const input = this._el("input", {
+            type: "text",
+            value: (col.filters?.assignees || []).join(", "),
+            placeholder: this._t("ed_preset_assignees_placeholder"),
+          });
+          input.addEventListener("change", () => {
+            const vals = input.value.split(",").map((s) => s.trim()).filter(Boolean);
+            const filters = { ...(col.filters || {}), assignees: vals.length ? vals : undefined };
+            if (!filters.assignees) delete filters.assignees;
+            updateCol({ filters: Object.keys(filters).length ? filters : undefined });
+          });
+          return this._el("div", { className: "field-wrap" }, [
+            input,
+            this._el("span", { textContent: this._t("ed_preset_assignees") }),
+          ]);
+        })(),
+        (() => {
+          const input = this._el("input", {
+            type: "text",
+            value: (col.filters?.labels || []).join(", "),
+            placeholder: this._t("ed_preset_labels_placeholder"),
+          });
+          input.addEventListener("change", () => {
+            const vals = input.value.split(",").map((s) => s.trim()).filter(Boolean);
+            const filters = { ...(col.filters || {}), labels: vals.length ? vals : undefined };
+            if (!filters.labels) delete filters.labels;
+            updateCol({ filters: Object.keys(filters).length ? filters : undefined });
+          });
+          return this._el("div", { className: "field-wrap" }, [
+            input,
+            this._el("span", { textContent: this._t("ed_preset_labels") }),
+          ]);
+        })(),
       ], false),
       this._buildSectionsEditor(col),
     ]);

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -137,6 +137,8 @@ const _TRANSLATIONS = {
     ed_preset_assignees_placeholder: "e.g. person.ben, person.anna",
     ed_preset_labels: "Labels (comma-separated)",
     ed_preset_labels_placeholder: "e.g. School, Morning Routine",
+    ed_show_only_due_today: "Due today only",
+    ed_show_only_due_today_include_overdue: "Include overdue",
   },
   nl: {
     my_tasks: "Mijn taken",
@@ -1072,6 +1074,8 @@ const _TRANSLATIONS = {
     ed_preset_assignees_placeholder: "z.B. person.ben, person.anna",
     ed_preset_labels: "Labels (kommagetrennt)",
     ed_preset_labels_placeholder: "z.B. Schule, Morgenroutine",
+    ed_show_only_due_today: "Nur heute fällig",
+    ed_show_only_due_today_include_overdue: "Überfällige einschließen",
   },
 };
 
@@ -1943,6 +1947,13 @@ class HomeTasksCard extends HTMLElement {
     if (preLabels && preLabels.length > 0) {
       const set = new Set(preLabels);
       tasks = tasks.filter((t) => t.tags && t.tags.some((tag) => set.has(tag)));
+    }
+    if (col.show_only_due_today === true) {
+      const includeOverdue = col.show_only_due_today_include_overdue === true;
+      tasks = tasks.filter((t) =>
+        this._isDueDateToday(t.due_date) ||
+        (includeOverdue && this._isDueDateOverdue(t.due_date))
+      );
     }
     return tasks;
   }
@@ -6377,6 +6388,29 @@ class HomeTasksCardEditor extends HTMLElement {
             daysInput,
             this._el("span", { textContent: this._t("ed_due_soon_days") }),
             this._el("div", { className: "spin-btns" }, [spinUp, spinDown]),
+          ]);
+        })()] : []),
+        (() => {
+          const sw = document.createElement("ha-switch");
+          sw.checked = col.show_only_due_today === true;
+          sw.setAttribute("aria-label", this._t("ed_show_only_due_today"));
+          sw.addEventListener("change", () => {
+            updateCol({ show_only_due_today: sw.checked });
+            this._render();
+          });
+          return this._el("div", { className: "toggle-row" }, [
+            this._el("span", { className: "toggle-label", textContent: this._t("ed_show_only_due_today") }),
+            sw,
+          ]);
+        })(),
+        ...(col.show_only_due_today === true ? [(() => {
+          const sw = document.createElement("ha-switch");
+          sw.checked = col.show_only_due_today_include_overdue === true;
+          sw.setAttribute("aria-label", this._t("ed_show_only_due_today_include_overdue"));
+          sw.addEventListener("change", () => updateCol({ show_only_due_today_include_overdue: sw.checked }));
+          return this._el("div", { className: "toggle-row" }, [
+            this._el("span", { className: "toggle-label", textContent: this._t("ed_show_only_due_today_include_overdue") }),
+            sw,
           ]);
         })()] : []),
         this._el("div", { className: "field" }, [filterLabel, filterSelect]),


### PR DESCRIPTION
## Summary

Implements #9 — show only tasks due today.

Instead of a separate `show_only_due_today` config key, this extends the
existing `due_soon_days` (Days ahead) feature to accept `0`, enabling a
"today only" scope via the existing Due Soon filter mechanism.

**Change:** Editor input minimum lowered from 1 → 0.

## Usage

```yaml
columns:
  - list_id: abc123
    show_due_soon_filter: true
    due_soon_days: 0
    default_filter: due_soon
```

This shows only tasks due today plus any overdue tasks. The user can still
switch to All/Open/Done if the filter bar is visible.

## Test plan

- [ ] `due_soon_days: 0` with `default_filter: due_soon` shows only today + overdue tasks
- [ ] Editor "Days ahead" spinner accepts and saves `0`
- [ ] Spin-down stops at `0`, not going negative
- [ ] Existing `due_soon_days: 7` (default) behavior unchanged