### PR TITLE
feat(service): multi-tag AND filter for reopen_task

### DIFF
--- a/custom_components/home_tasks/__init__.py
+++ b/custom_components/home_tasks/__init__.py
@@ -956,27 +956,39 @@ def _async_register_services(hass: HomeAssistant) -> None:
         task_title = call.data.get("task_title")
         assigned_person = call.data.get("assigned_person")
         tag = call.data.get("tag")
+        tags_raw = call.data.get("tags")
+
+        # Build the required tag set.  `tags` (comma-separated, AND-logic) takes
+        # precedence over the legacy `tag` (single value).  Both remain supported
+        # for backwards compatibility.
+        if tags_raw:
+            required_tags = {t.strip().lower() for t in tags_raw.split(",") if t.strip()}
+        elif tag:
+            required_tags = {tag.strip().lower()}
+        else:
+            required_tags = set()
 
         if task_id or task_title:
             # Reopen a single task
             task = _resolve_task(store, call.data)
             if task.get("completed"):
                 await store.async_reopen_task(task["id"], actor=actor)
-        elif assigned_person or tag:
-            # Reopen completed tasks matching person and/or tag
+        elif assigned_person or required_tags:
+            # Reopen completed tasks matching person and/or tag(s).
+            # When multiple tags are given, ALL must be present on the task (AND).
             for task in store.tasks:
                 if not task.get("completed"):
                     continue
                 if assigned_person and task.get("assigned_person") != assigned_person:
                     continue
-                if tag and tag.strip().lower() not in (
-                    t.lower() for t in task.get("tags", [])
-                ):
-                    continue
+                if required_tags:
+                    task_tags = {t.lower() for t in task.get("tags", [])}
+                    if not required_tags.issubset(task_tags):
+                        continue
                 await store.async_reopen_task(task["id"], actor=actor)
         else:
             raise vol.Invalid(
-                "Either task_id, task_title, assigned_person, or tag must be provided"
+                "Either task_id, task_title, assigned_person, tag, or tags must be provided"
             )
 
     hass.services.async_register(
@@ -1019,6 +1031,7 @@ def _async_register_services(hass: HomeAssistant) -> None:
             vol.Optional("task_title"): cv.string,
             vol.Optional("assigned_person"): cv.string,
             vol.Optional("tag"): cv.string,
+            vol.Optional("tags"): cv.string,
         }),
     )
     _LOGGER.info("Home Tasks services registered")

--- a/custom_components/home_tasks/services.yaml
+++ b/custom_components/home_tasks/services.yaml
@@ -143,3 +143,12 @@ reopen_task:
         assigned_person to narrow the selection.
       selector:
         text:
+    tags:
+      name: Tags (ALL must match)
+      description: >-
+        Comma-separated list of tags. Only tasks that carry ALL specified tags
+        are reopened (AND-logic). Supersedes the single `tag` field when both
+        are provided. Can be combined with assigned_person.
+        Example: "fussball_mittag, ferien_ja"
+      selector:
+        text:

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -318,6 +318,65 @@ async def test_service_reopen_task_by_tag(hass: HomeAssistant, mock_config_entry
     assert store.get_task(t3["id"])["completed"] is True  # no tag match
 
 
+async def test_service_reopen_task_by_tags_all_must_match(
+    hass: HomeAssistant, mock_config_entry, store
+) -> None:
+    """reopen_task with tags= uses AND-logic: all tags must be present."""
+    t1 = await store.async_add_task("Has both tags")
+    t2 = await store.async_add_task("Has only first tag")
+    t3 = await store.async_add_task("Has only second tag")
+    t4 = await store.async_add_task("Has neither tag")
+    await store.async_update_task(t1["id"], tags=["fussball_mittag", "ferien_ja"])
+    await store.async_update_task(t2["id"], tags=["fussball_mittag"])
+    await store.async_update_task(t3["id"], tags=["ferien_ja"])
+    await store.async_update_task(t4["id"], tags=["other"])
+    for t in (t1, t2, t3, t4):
+        await store.async_update_task(t["id"], completed=True)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "reopen_task",
+        {"list_name": "Test List", "tags": "fussball_mittag, ferien_ja"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert store.get_task(t1["id"])["completed"] is False  # both tags → reopened
+    assert store.get_task(t2["id"])["completed"] is True   # missing ferien_ja → skipped
+    assert store.get_task(t3["id"])["completed"] is True   # missing fussball_mittag → skipped
+    assert store.get_task(t4["id"])["completed"] is True   # no matching tags → skipped
+
+
+async def test_service_reopen_task_tags_with_assigned_person(
+    hass: HomeAssistant, mock_config_entry, store
+) -> None:
+    """reopen_task with tags= and assigned_person= narrows by both."""
+    t1 = await store.async_add_task("Laurin fussball ferien")
+    t2 = await store.async_add_task("Lina fussball ferien")
+    t3 = await store.async_add_task("Laurin fussball no ferien")
+    for t, person, tags in [
+        (t1, "person.laurin", ["fussball_mittag", "ferien_ja"]),
+        (t2, "person.lina",   ["fussball_mittag", "ferien_ja"]),
+        (t3, "person.laurin", ["fussball_mittag"]),
+    ]:
+        await store.async_update_task(t["id"], assigned_person=person, tags=tags)
+        await store.async_update_task(t["id"], completed=True)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "reopen_task",
+        {
+            "list_name": "Test List",
+            "tags": "fussball_mittag, ferien_ja",
+            "assigned_person": "person.laurin",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert store.get_task(t1["id"])["completed"] is False  # Laurin + both tags → reopened
+    assert store.get_task(t2["id"])["completed"] is True   # wrong person → skipped
+    assert store.get_task(t3["id"])["completed"] is True   # missing ferien_ja → skipped
+
+
 async def test_service_reopen_task_by_assigned_person(
     hass: HomeAssistant, mock_config_entry, store
 ) -> None:


### PR DESCRIPTION
## Problem

Automations that manage child-specific routine tasks need to open tasks that match **multiple conditions simultaneously** — e.g. only tasks tagged `fussball_mittag` **and** `ferien_ja`. The existing `tag` field only supports a single tag, making this impossible without restructuring the task taxonomy.

## Solution

Add a `tags` field (comma-separated) with AND-logic: a task is only reopened if it carries **all** of the specified tags.

```yaml
- action: home_tasks.reopen_task
  data:
    list_name: Kinder Routine
    tags: "fussball_mittag, ferien_ja"
    assigned_person: person.laurin
```

This reopens only tasks tagged with **both** `fussball_mittag` and `ferien_ja` — leaving Hausaufgaben tasks (no `ferien_ja`) untouched during school holidays.

## Backwards compatibility

The existing `tag` field is **unchanged**. `tags` supersedes `tag` when both are provided.

## Changes

- `__init__.py`: parse `tags` into a set; use `set.issubset()` for matching
- `services.yaml`: document new `tags` field with example
- `tests/integration/test_init.py`: two new tests
  - AND-logic: only tasks with all required tags are reopened
  - combined with `assigned_person`: both filters apply simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)