### PR TITLE
fix(card): real-time cross-device sync for native lists

### DIFF
--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -1296,14 +1296,28 @@ class HomeTasksCard extends HTMLElement {
       this._loadLists();
       return;
     }
-    // Reload when any external entity's state object changes (new reference = entity updated)
+    // Reload when any watched entity's state object changes (new reference = entity updated).
+    // Covers both external todo entities and native-list sensor entities (for cross-device sync).
     if (prev && hass) {
       for (const col of this._config.columns) {
-        if (!col.entity_id) continue;
-        if (prev.states?.[col.entity_id] !== hass.states?.[col.entity_id]) {
-          this._isBackgroundUpdate = true;
-          this._loadAllTasks().finally(() => { this._isBackgroundUpdate = false; });
-          return;
+        // --- External list: watch the todo entity directly ---
+        if (col.entity_id) {
+          if (prev.states?.[col.entity_id] !== hass.states?.[col.entity_id]) {
+            this._isBackgroundUpdate = true;
+            this._loadAllTasks().finally(() => { this._isBackgroundUpdate = false; });
+            return;
+          }
+        }
+        // --- Native list: watch its open-tasks sensor so changes on other
+        //     devices/tabs propagate here without manual refresh ---
+        if (col.list_id) {
+          const list = (this._lists || []).find(l => l.id === col.list_id);
+          const seid = list?.sensor_entity_id;
+          if (seid && prev.states?.[seid] !== hass.states?.[seid]) {
+            this._isBackgroundUpdate = true;
+            this._loadAllTasks().finally(() => { this._isBackgroundUpdate = false; });
+            return;
+          }
         }
       }
     }

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -96,18 +96,25 @@ async def ws_get_lists(hass, connection, msg):
     """Get all lists (native config entries only)."""
     try:
         from .store import HomeTasksStore
+        from homeassistant.helpers import entity_registry as er
 
         stores = hass.data.get(DOMAIN, {})
         entries = hass.config_entries.async_entries(DOMAIN)
+        entity_reg = er.async_get(hass)
         lists = []
         for entry in entries:
             if entry.data.get("type") == "external":
                 continue  # external lists handled by ws_get_external_lists
             store = stores.get(entry.entry_id)
+            # Resolve the sensor entity ID so the frontend can subscribe to
+            # state-changed events for real-time cross-device updates.
+            sensor_unique_id = f"{entry.entry_id}_open_tasks"
+            sensor_entity_id = entity_reg.async_get_entity_id("sensor", DOMAIN, sensor_unique_id)
             lists.append({
                 "id": entry.entry_id,
                 "name": entry.data.get("name", entry.title),
                 "task_count": len(store.tasks) if store and isinstance(store, HomeTasksStore) else 0,
+                "sensor_entity_id": sensor_entity_id,
             })
         connection.send_result(msg["id"], {"lists": lists})
     except Exception as err:


### PR DESCRIPTION
## Problem

Native home_tasks lists (`list_id` columns) were never updated when tasks changed on another device or tab. Checking a task on Android did not appear on the dashboard, and adding a task in one browser tab was invisible to another.

## Root Cause

The card's `set hass()` hook only watched `col.entity_id` (external todo entities like Todoist). For native lists (`list_id`), there was no watched entity, so HA's WebSocket state-change push was ignored.

The backend already calls `async_write_ha_state()` on the list's `sensor.{list}_open_tasks` entity whenever tasks change — we just weren't listening for it in the frontend.

## Fix

**Backend (`websocket_api.py`):**
`ws_get_lists` now resolves the `sensor_entity_id` for each native list via the entity registry and includes it in the response.

**Frontend (`home-tasks-card.js`):**
`set hass()` now also watches the sensor entity for each native-list column (alongside existing external entity watching). Any state reference change triggers a silent background `_loadAllTasks()` reload.

## How it works

1. Device A completes a task → store calls `async_write_ha_state()`
2. HA sensor state changes → HA pushes `state_changed` over WebSocket to all clients
3. Every connected card's `set hass(hass)` fires
4. Card detects the sensor state changed → triggers background `_loadAllTasks()`
5. Device B / other tab sees updated task list without any manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)