### PR TITLE
feat(card): voice input via HA assist_pipeline/run STT + Web Speech API fallback

### DIFF
--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -1202,6 +1202,7 @@ class HomeTasksCard extends HTMLElement {
     // takes over) or they pick "Ab Erledigung" (which clears the override).
     this._weekPatternOverride = new Map();   // task.id → "on"
     this._yearPatternOverride = new Map();   // task.id → "on"
+    this._voiceActive = new Map();           // colIdx → SpeechRecognition
   }
 
   _defaultColState() {
@@ -2525,6 +2526,53 @@ class HomeTasksCard extends HTMLElement {
       : null;
   }
 
+  _startVoiceInput(colIdx) {
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SR) {
+      alert("Spracheingabe wird von diesem Browser nicht unterstützt (Chrome/Edge/Safari).");
+      return;
+    }
+    // Toggle off if already recording
+    if (this._voiceActive.has(colIdx)) {
+      this._voiceActive.get(colIdx).abort();
+      this._voiceActive.delete(colIdx);
+      this._render();
+      return;
+    }
+    const recognition = new SR();
+    recognition.lang = this._config.voice_lang || "de-DE";
+    recognition.interimResults = true;
+    recognition.maxAlternatives = 1;
+    recognition.continuous = false;
+    this._voiceActive.set(colIdx, recognition);
+    this._render();
+    recognition.onresult = (event) => {
+      const result = event.results[event.results.length - 1];
+      const cs = this._columns[colIdx];
+      if (cs) cs.newTaskTitle = result[0].transcript;
+      if (result.isFinal) {
+        this._voiceActive.delete(colIdx);
+        this._render();
+      } else {
+        // Update input live for interim results without full re-render
+        const inp = this.shadowRoot.querySelector(`.add-input[data-focus-key="add_task_col_${colIdx}"]`);
+        if (inp) inp.value = result[0].transcript;
+      }
+    };
+    recognition.onerror = (e) => {
+      console.warn("voice input error:", e.error);
+      this._voiceActive.delete(colIdx);
+      this._render();
+    };
+    recognition.onend = () => {
+      if (this._voiceActive.has(colIdx)) {
+        this._voiceActive.delete(colIdx);
+        this._render();
+      }
+    };
+    recognition.start();
+  }
+
   _buildColumnAddTask(cs, colIdx) {
     const addInput = this._el("input", {
       type: "text",
@@ -2537,9 +2585,18 @@ class HomeTasksCard extends HTMLElement {
     addInput.addEventListener("keydown", (e) => {
       if (e.key === "Enter") this._addTask(colIdx);
     });
+    const isRecording = this._voiceActive.has(colIdx);
+    const micBtn = this._el("button", {
+      className: "mic-btn" + (isRecording ? " recording" : ""),
+      title: isRecording ? "Aufnahme stoppen" : "Spracheingabe",
+      innerHTML: isRecording
+        ? `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="15" height="15"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>`
+        : `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="15" height="15"><path d="M12 15c1.66 0 3-1.34 3-3V6c0-1.66-1.34-3-3-3S9 4.34 9 6v6c0 1.66 1.34 3 3 3zm-1-9c0-.55.45-1 1-1s1 .45 1 1v6c0 .55-.45 1-1 1s-1-.45-1-1V6zm6 6c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-2.08c3.39-.49 6-3.39 6-6.92h-2z"/></svg>`,
+    });
+    micBtn.addEventListener("click", () => this._startVoiceInput(colIdx));
     const addBtn = this._el("button", { className: "add-btn", textContent: "+" });
     addBtn.addEventListener("click", () => this._addTask(colIdx));
-    return this._el("div", { className: "add-task" }, [addInput, addBtn]);
+    return this._el("div", { className: "add-task" }, [addInput, micBtn, addBtn]);
   }
 
   _buildColumnSortControl(col, cs, colIdx) {
@@ -5464,6 +5521,23 @@ class HomeTasksCard extends HTMLElement {
         font-weight: 500; cursor: pointer; white-space: nowrap; font-family: inherit;
       }
       .add-btn:hover { opacity: 0.9; }
+      .mic-btn {
+        flex-shrink: 0; width: 38px; height: 38px; padding: 0;
+        border: 1px solid var(--todo-divider); border-radius: var(--todo-radius);
+        background: var(--todo-bg); color: var(--todo-secondary-text);
+        cursor: pointer; display: flex; align-items: center; justify-content: center;
+        transition: border-color 0.2s, color 0.2s;
+      }
+      .mic-btn:hover { border-color: var(--todo-primary); color: var(--todo-primary); }
+      .mic-btn svg { width: 18px; height: 18px; fill: currentColor; }
+      .mic-btn.recording {
+        border-color: #e53935; color: #e53935;
+        animation: mic-pulse 1s ease-in-out infinite;
+      }
+      @keyframes mic-pulse {
+        0%, 100% { box-shadow: 0 0 0 0 rgba(229, 57, 53, 0.4); }
+        50% { box-shadow: 0 0 0 6px rgba(229, 57, 53, 0); }
+      }
       .filters { display: flex; gap: 4px; margin-bottom: 12px; align-items: center; }
       .filter-spacer { flex: 1; }
       .filter-btn {
@@ -5854,6 +5928,8 @@ class HomeTasksCard extends HTMLElement {
       .compact .add-task { margin-bottom: 10px; }
       .compact .add-input { padding: 6px 10px; font-size: 13px; }
       .compact .add-btn { padding: 6px 14px; font-size: 13px; }
+      .compact .mic-btn { width: 32px; height: 32px; }
+      .compact .mic-btn svg { width: 15px; height: 15px; }
       .compact .filters { margin-bottom: 8px; }
       .compact .filter-btn { padding: 4px 12px; font-size: 12px; }
       .compact .tag-chips { margin-bottom: 8px; gap: 3px; }

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -2835,41 +2835,49 @@ class HomeTasksCard extends HTMLElement {
 
   _showTileAddDialog(colIdx) {
     const cs = this._columns[colIdx];
+    this.shadowRoot.querySelector(".tile-add-overlay")?.remove();
 
+    const close = () => overlay.remove();
     const doAdd = async () => {
-      const title = (tf.value || "").trim();
+      const title = input.value.trim();
       if (!title) return;
-      dlg.open = false;
+      close();
       cs.newTaskTitle = title;
       await this._addTask(colIdx);
     };
 
-    const tf = document.createElement("ha-textfield");
-    tf.setAttribute("label", this._t("add_placeholder"));
-    tf.setAttribute("dialogInitialFocus", "");
-    tf.style.width = "100%";
-    tf.addEventListener("keydown", (e) => {
+    const input = this._el("input", {
+      type: "text", className: "tile-dialog-input",
+      placeholder: this._t("add_placeholder"),
+    });
+    input.addEventListener("keydown", (e) => {
       if (e.key === "Enter") doAdd();
-      if (e.key === "Escape") { dlg.open = false; }
+      if (e.key === "Escape") close();
     });
 
-    const cancelBtn = document.createElement("mwc-button");
-    cancelBtn.slot = "secondaryAction";
-    cancelBtn.setAttribute("dialogAction", "close");
-    cancelBtn.textContent = this._t("dialog_cancel");
+    const cancelBtn = this._el("button", {
+      className: "tile-dialog-btn tile-dialog-cancel",
+      textContent: this._t("dialog_cancel"),
+    });
+    cancelBtn.addEventListener("click", close);
 
-    const confirmBtn = document.createElement("mwc-button");
-    confirmBtn.slot = "primaryAction";
-    confirmBtn.setAttribute("raised", "");
-    confirmBtn.textContent = this._t("dialog_add");
+    const confirmBtn = this._el("button", {
+      className: "tile-dialog-btn tile-dialog-confirm",
+      textContent: this._t("dialog_add"),
+    });
     confirmBtn.addEventListener("click", doAdd);
 
-    const dlg = document.createElement("ha-dialog");
-    dlg.heading = this._t("add_placeholder");
-    dlg.open = true;
-    dlg.append(tf, cancelBtn, confirmBtn);
-    dlg.addEventListener("closed", () => dlg.remove(), { once: true });
-    document.body.appendChild(dlg);
+    const dialog = this._el("div", { className: "tile-dialog" }, [
+      input,
+      this._el("div", { className: "tile-dialog-actions" }, [cancelBtn, confirmBtn]),
+    ]);
+    dialog.addEventListener("click", (e) => e.stopPropagation());
+
+    const overlay = this._el("div", { className: "tile-add-overlay" }, [dialog]);
+    overlay.addEventListener("click", close);
+
+    this.shadowRoot.appendChild(overlay);
+    requestAnimationFrame(() => input.focus());
   }
 
   _buildTaskTile(task, colIdx) {
@@ -5935,6 +5943,38 @@ class HomeTasksCard extends HTMLElement {
         background: color-mix(in srgb, var(--primary-color) 8%, transparent);
       }
       .add-tile-icon { font-size: 2.2rem; font-weight: 300; line-height: 1; pointer-events: none; }
+
+      /* Add-task dialog overlay */
+      .tile-add-overlay {
+        position: fixed; inset: 0; z-index: 9999;
+        background: rgba(0,0,0,0.42);
+        display: flex; align-items: center; justify-content: center;
+      }
+      .tile-dialog {
+        background: var(--ha-card-background, var(--card-background-color, #1c1c1c));
+        border-radius: 28px; padding: 24px 24px 16px;
+        min-width: 280px; max-width: min(420px, 90vw);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+        display: flex; flex-direction: column; gap: 16px;
+      }
+      .tile-dialog-input {
+        width: 100%; box-sizing: border-box;
+        padding: 14px 0 10px;
+        border: none; border-bottom: 2px solid var(--divider-color, rgba(255,255,255,0.12));
+        background: transparent; color: var(--primary-text-color);
+        font-size: 16px; font-family: inherit; outline: none;
+      }
+      .tile-dialog-input:focus { border-bottom-color: var(--primary-color); }
+      .tile-dialog-input::placeholder { color: var(--secondary-text-color); }
+      .tile-dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
+      .tile-dialog-btn {
+        padding: 10px 20px; border: none; border-radius: 20px;
+        font-size: 14px; font-weight: 500; font-family: inherit; cursor: pointer;
+      }
+      .tile-dialog-cancel { background: transparent; color: var(--primary-color); }
+      .tile-dialog-cancel:hover { background: color-mix(in srgb, var(--primary-color) 10%, transparent); }
+      .tile-dialog-confirm { background: var(--primary-color); color: var(--text-primary-color, #fff); }
+      .tile-dialog-confirm:hover { filter: brightness(1.08); }
 
       /* Compact tile variant */
       .compact .tile-grid-inner { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 7px; }

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -1202,7 +1202,7 @@ class HomeTasksCard extends HTMLElement {
     // takes over) or they pick "Ab Erledigung" (which clears the override).
     this._weekPatternOverride = new Map();   // task.id → "on"
     this._yearPatternOverride = new Map();   // task.id → "on"
-    this._voiceActive = new Map();           // colIdx → SpeechRecognition
+    this._voiceActive = new Map();           // colIdx → cleanup function
   }
 
   _defaultColState() {
@@ -1388,6 +1388,8 @@ class HomeTasksCard extends HTMLElement {
         el.title = val;
       } else if (key === "htmlFor") {
         el.htmlFor = val;
+      } else if (key === "innerHTML") {
+        el.innerHTML = val;
       } else {
         el.setAttribute(key, val);
       }
@@ -2526,51 +2528,220 @@ class HomeTasksCard extends HTMLElement {
       : null;
   }
 
-  _startVoiceInput(colIdx) {
-    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
-    if (!SR) {
-      alert("Spracheingabe wird von diesem Browser nicht unterstützt (Chrome/Edge/Safari).");
-      return;
-    }
+  // Start voice input. colIdx identifies the column; inputEl is the <input>
+  // element to fill (list-row input or tile-dialog input). If omitted the
+  // column's newTaskTitle state is updated instead (legacy path).
+  _startVoiceInput(colIdx, inputEl = null) {
     // Toggle off if already recording
     if (this._voiceActive.has(colIdx)) {
-      this._voiceActive.get(colIdx).abort();
-      this._voiceActive.delete(colIdx);
-      this._render();
+      this._voiceActive.get(colIdx)(); // call cleanup
       return;
+    }
+
+    // Helper: update the visible input + column state
+    const setTranscript = (text) => {
+      const cs = this._columns[colIdx];
+      if (cs) cs.newTaskTitle = text;
+      if (inputEl) {
+        inputEl.value = text;
+      } else {
+        const inp = this.shadowRoot.querySelector(`.add-input[data-focus-key="add_task_col_${colIdx}"]`);
+        if (inp) inp.value = text;
+      }
+    };
+
+    const stopRecording = () => {
+      const cleanup = this._voiceActive.get(colIdx);
+      if (cleanup) cleanup();
+    };
+
+    // Try HA assist_pipeline first, then fall back to Web Speech API
+    this._startHAStt(colIdx, inputEl, setTranscript, stopRecording)
+      .catch(() => this._startWebSpeech(colIdx, inputEl, setTranscript));
+  }
+
+  // Primary: HA assist_pipeline/run STT (streams raw PCM to HA's STT backend)
+  async _startHAStt(colIdx, inputEl, setTranscript) {
+    if (!this.hass || !this.hass.connection) throw new Error("no hass");
+
+    // Request microphone access early so we can fail fast if denied
+    let stream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      throw new Error("mic denied: " + err.message);
+    }
+
+    const lang = this._config.voice_lang || (this.hass.language || "de-DE");
+
+    // Mutable refs inside the shared cleanup closure
+    let audioRefs = null; // { audioCtx, processor }
+    let unsub = null;
+    let cleaned = false;
+
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      if (audioRefs) {
+        try { audioRefs.processor.disconnect(); } catch (_) {}
+        try { audioRefs.audioCtx.close(); } catch (_) {}
+        // Send empty buffer to signal end of audio stream to HA
+        try { this.hass.connection.socket.send(new ArrayBuffer(0)); } catch (_) {}
+        audioRefs = null;
+      }
+      if (stream) { stream.getTracks().forEach(t => t.stop()); stream = null; }
+      if (unsub) { try { unsub(); } catch (_) {} unsub = null; }
+      this._voiceActive.delete(colIdx);
+      this._updateMicBtn(colIdx, inputEl, false);
+    };
+
+    this._voiceActive.set(colIdx, cleanup);
+    this._updateMicBtn(colIdx, inputEl, true);
+
+    // Subscribe to pipeline events
+    try {
+      unsub = await this.hass.connection.subscribeMessage(
+        (event) => {
+          if (!event || !event.type) return;
+          if (event.type === "stt-start") {
+            // HA is ready – start streaming audio
+            audioRefs = this._streamPcmAudio(stream, cleanup);
+          } else if (event.type === "stt-end") {
+            const text = event.data?.stt_output?.text || "";
+            if (text) setTranscript(text);
+            cleanup();
+          } else if (event.type === "error") {
+            console.warn("HA STT error:", event.data);
+            cleanup();
+            // Fall back to Web Speech
+            this._startWebSpeech(colIdx, inputEl, setTranscript);
+          } else if (event.type === "run-end") {
+            cleanup();
+          }
+        },
+        {
+          type: "assist_pipeline/run",
+          start_stage: "stt",
+          end_stage: "stt",
+          input: { sample_rate: 16000 },
+          language: lang,
+        }
+      );
+    } catch (err) {
+      cleanup();
+      throw err; // triggers fallback in _startVoiceInput
+    }
+  }
+
+  // Stream PCM audio from the MediaStream to HA via binary WebSocket frames.
+  // Returns { audioCtx, processor } for the caller to store and disconnect later.
+  _streamPcmAudio(stream, onError) {
+    const SAMPLE_RATE = 16000;
+    const BUFFER_SIZE = 4096;
+    try {
+      const audioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: SAMPLE_RATE });
+      const source = audioCtx.createMediaStreamSource(stream);
+      const processor = audioCtx.createScriptProcessor(BUFFER_SIZE, 1, 1);
+
+      processor.onaudioprocess = (e) => {
+        const float32 = e.inputBuffer.getChannelData(0);
+        const pcm16 = new Int16Array(float32.length);
+        for (let i = 0; i < float32.length; i++) {
+          pcm16[i] = Math.max(-32768, Math.min(32767, float32[i] * 32767));
+        }
+        try {
+          this.hass.connection.socket.send(pcm16.buffer);
+        } catch (err) {
+          if (onError) onError(err);
+        }
+      };
+
+      source.connect(processor);
+      processor.connect(audioCtx.destination);
+      return { audioCtx, processor };
+    } catch (err) {
+      console.warn("PCM stream setup failed:", err);
+      // Send empty buffer to signal end of audio
+      try { this.hass.connection.socket.send(new ArrayBuffer(0)); } catch (_) {}
+      if (onError) onError(err);
+      return null;
+    }
+  }
+
+  // Fallback: Web Speech API (browser-native, less accurate)
+  _startWebSpeech(colIdx, inputEl, setTranscript) {
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SR) {
+      this._updateMicBtn(colIdx, inputEl, false);
+      return; // silently skip if not supported
+    }
+    // Don't start if already cancelled (user toggled off)
+    if (!this._voiceActive.has(colIdx)) {
+      // Was already cleaned up; mark as active again for Web Speech
     }
     const recognition = new SR();
     recognition.lang = this._config.voice_lang || "de-DE";
     recognition.interimResults = true;
-    recognition.maxAlternatives = 1;
+    recognition.maxAlternatives = 3;
     recognition.continuous = false;
-    this._voiceActive.set(colIdx, recognition);
-    this._render();
+
+    const cleanup = () => {
+      try { recognition.abort(); } catch (_) {}
+      this._voiceActive.delete(colIdx);
+      this._updateMicBtn(colIdx, inputEl, false);
+    };
+    this._voiceActive.set(colIdx, cleanup);
+    this._updateMicBtn(colIdx, inputEl, true);
+
     recognition.onresult = (event) => {
       const result = event.results[event.results.length - 1];
-      const cs = this._columns[colIdx];
-      if (cs) cs.newTaskTitle = result[0].transcript;
+      const transcript = result[0].transcript;
+      setTranscript(transcript);
       if (result.isFinal) {
         this._voiceActive.delete(colIdx);
-        this._render();
-      } else {
-        // Update input live for interim results without full re-render
-        const inp = this.shadowRoot.querySelector(`.add-input[data-focus-key="add_task_col_${colIdx}"]`);
-        if (inp) inp.value = result[0].transcript;
+        this._updateMicBtn(colIdx, inputEl, false);
       }
     };
     recognition.onerror = (e) => {
-      console.warn("voice input error:", e.error);
-      this._voiceActive.delete(colIdx);
-      this._render();
+      console.warn("Web Speech error:", e.error);
+      cleanup();
     };
     recognition.onend = () => {
-      if (this._voiceActive.has(colIdx)) {
-        this._voiceActive.delete(colIdx);
-        this._render();
-      }
+      if (this._voiceActive.has(colIdx)) cleanup();
     };
-    recognition.start();
+    try {
+      recognition.start();
+    } catch (err) {
+      cleanup();
+    }
+  }
+
+  // Update the mic button state without a full re-render.
+  // inputEl: if set, update a mic-btn inside the tile dialog; else find
+  // the column-level mic-btn via data attribute.
+  _updateMicBtn(colIdx, inputEl, recording) {
+    const MIC_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="15" height="15"><path d="M12 15c1.66 0 3-1.34 3-3V6c0-1.66-1.34-3-3-3S9 4.34 9 6v6c0 1.66 1.34 3 3 3zm-1-9c0-.55.45-1 1-1s1 .45 1 1v6c0 .55-.45 1-1 1s-1-.45-1-1V6zm6 6c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-2.08c3.39-.49 6-3.39 6-6.92h-2z"/></svg>`;
+    const STOP_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="15" height="15"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>`;
+
+    let btn;
+    if (inputEl) {
+      // Tile dialog mic button is a sibling of the input inside the dialog
+      btn = inputEl.closest(".tile-dialog")?.querySelector(".mic-btn");
+    } else {
+      btn = this.shadowRoot.querySelector(`.mic-btn[data-col-idx="${colIdx}"]`);
+    }
+    if (!btn) {
+      // Fall back to full re-render if button not found
+      this._render();
+      return;
+    }
+    btn.innerHTML = recording ? STOP_SVG : MIC_SVG;
+    btn.title = recording ? "Aufnahme stoppen" : "Spracheingabe";
+    if (recording) {
+      btn.classList.add("recording");
+    } else {
+      btn.classList.remove("recording");
+    }
   }
 
   _buildColumnAddTask(cs, colIdx) {
@@ -2589,6 +2760,7 @@ class HomeTasksCard extends HTMLElement {
     const micBtn = this._el("button", {
       className: "mic-btn" + (isRecording ? " recording" : ""),
       title: isRecording ? "Aufnahme stoppen" : "Spracheingabe",
+      "data-col-idx": String(colIdx),
       innerHTML: isRecording
         ? `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="15" height="15"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>`
         : `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="15" height="15"><path d="M12 15c1.66 0 3-1.34 3-3V6c0-1.66-1.34-3-3-3S9 4.34 9 6v6c0 1.66 1.34 3 3 3zm-1-9c0-.55.45-1 1-1s1 .45 1 1v6c0 .55-.45 1-1 1s-1-.45-1-1V6zm6 6c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-2.08c3.39-.49 6-3.39 6-6.92h-2z"/></svg>`,

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -11,6 +11,7 @@ const _TRANSLATIONS = {
   en: {
     my_tasks: "My Tasks",
     add_placeholder: "Add new task...",
+    dialog_cancel: "Cancel", dialog_add: "Add",
     filter_all: "All",
     filter_open: "Open",
     filter_done: "Done",
@@ -143,6 +144,7 @@ const _TRANSLATIONS = {
   nl: {
     my_tasks: "Mijn taken",
     add_placeholder: "Nieuwe taak toevoegen...",
+    dialog_cancel: "Annuleren", dialog_add: "Toevoegen",
     filter_all: "Alle", filter_open: "Open", filter_done: "Klaar", filter_due_soon: "Binnenkort",
     ed_show_due_soon_filter: "Binnenkort-filter", ed_due_soon_days: "Dagen vooruit", ed_hide_overdue: "Verlopen verbergen",
     progress: "{0} van {1} klaar",
@@ -209,6 +211,7 @@ const _TRANSLATIONS = {
   it: {
     my_tasks: "Le mie attivit\u00e0",
     add_placeholder: "Aggiungi nuova attivit\u00e0...",
+    dialog_cancel: "Annulla", dialog_add: "Aggiungi",
     filter_all: "Tutte", filter_open: "Aperte", filter_done: "Completate", filter_due_soon: "In scadenza",
     ed_show_due_soon_filter: "Filtro in scadenza", ed_due_soon_days: "Giorni avanti", ed_hide_overdue: "Nascondi scadute",
     progress: "{0} di {1} completate",
@@ -275,6 +278,7 @@ const _TRANSLATIONS = {
   pl: {
     my_tasks: "Moje zadania",
     add_placeholder: "Dodaj nowe zadanie...",
+    dialog_cancel: "Anuluj", dialog_add: "Dodaj",
     filter_all: "Wszystkie", filter_open: "Otwarte", filter_done: "Uko\u0144czone", filter_due_soon: "Wkr\u00f3tce",
     ed_show_due_soon_filter: "Filtr wkr\u00f3tce", ed_due_soon_days: "Dni naprz\u00f3d", ed_hide_overdue: "Ukryj zaleg\u0142e",
     progress: "{0} z {1} uko\u0144czono",
@@ -341,6 +345,7 @@ const _TRANSLATIONS = {
   sv: {
     my_tasks: "Mina uppgifter",
     add_placeholder: "L\u00e4gg till ny uppgift...",
+    dialog_cancel: "Avbryt", dialog_add: "L\u00e4gg till",
     filter_all: "Alla", filter_open: "\u00d6ppna", filter_done: "Klara", filter_due_soon: "Snart",
     ed_show_due_soon_filter: "Snart-filter", ed_due_soon_days: "Dagar fram\u00e5t", ed_hide_overdue: "D\u00f6lj f\u00f6rsenade",
     progress: "{0} av {1} klara",
@@ -407,6 +412,7 @@ const _TRANSLATIONS = {
   fr: {
     my_tasks: "Mes t\u00e2ches",
     add_placeholder: "Ajouter une nouvelle t\u00e2che...",
+    dialog_cancel: "Annuler", dialog_add: "Ajouter",
     filter_all: "Toutes", filter_open: "Ouvertes", filter_done: "Termin\u00e9es", filter_due_soon: "Bient\u00f4t",
     ed_show_due_soon_filter: "Filtre bient\u00f4t", ed_due_soon_days: "Jours \u00e0 venir", ed_hide_overdue: "Masquer en retard",
     progress: "{0} sur {1} termin\u00e9es",
@@ -473,6 +479,7 @@ const _TRANSLATIONS = {
   pt: {
     my_tasks: "Minhas tarefas",
     add_placeholder: "Adicionar nova tarefa...",
+    dialog_cancel: "Cancelar", dialog_add: "Adicionar",
     filter_all: "Todas", filter_open: "Abertas", filter_done: "Conclu\u00eddas", filter_due_soon: "Em breve",
     ed_show_due_soon_filter: "Filtro em breve", ed_due_soon_days: "Dias \u00e0 frente", ed_hide_overdue: "Ocultar atrasadas",
     progress: "{0} de {1} conclu\u00eddas",
@@ -539,6 +546,7 @@ const _TRANSLATIONS = {
   es: {
     my_tasks: "Mis tareas",
     add_placeholder: "A\u00f1adir nueva tarea...",
+    dialog_cancel: "Cancelar", dialog_add: "Agregar",
     filter_all: "Todas", filter_open: "Abiertas", filter_done: "Completadas", filter_due_soon: "Pr\u00f3ximamente",
     ed_show_due_soon_filter: "Filtro pr\u00f3ximo", ed_due_soon_days: "D\u00edas adelante", ed_hide_overdue: "Ocultar vencidas",
     progress: "{0} de {1} completadas",
@@ -605,6 +613,7 @@ const _TRANSLATIONS = {
   ru: {
     my_tasks: "\u041c\u043e\u0438 \u0437\u0430\u0434\u0430\u0447\u0438",
     add_placeholder: "\u0414\u043e\u0431\u0430\u0432\u0438\u0442\u044c \u043d\u043e\u0432\u0443\u044e \u0437\u0430\u0434\u0430\u0447\u0443...",
+    dialog_cancel: "\u041e\u0442\u043c\u0435\u043d\u0430", dialog_add: "\u0414\u043e\u0431\u0430\u0432\u0438\u0442\u044c",
     filter_all: "\u0412\u0441\u0435", filter_open: "\u041e\u0442\u043a\u0440\u044b\u0442\u044b\u0435", filter_done: "\u0412\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u043d\u044b\u0435", filter_due_soon: "\u0421\u043a\u043e\u0440\u043e",
     ed_show_due_soon_filter: "\u0424\u0438\u043b\u044c\u0442\u0440 \u0441\u043a\u043e\u0440\u043e", ed_due_soon_days: "\u0414\u043d\u0435\u0439 \u0432\u043f\u0435\u0440\u0451\u0434", ed_hide_overdue: "\u0421\u043a\u0440\u044b\u0442\u044c \u043f\u0440\u043e\u0441\u0440\u043e\u0447\u0435\u043d\u043d\u044b\u0435",
     progress: "{0} \u0438\u0437 {1} \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u043e",
@@ -671,6 +680,7 @@ const _TRANSLATIONS = {
   cs: {
     my_tasks: "Moje \u00fakoly",
     add_placeholder: "P\u0159idat nov\u00fd \u00fakol...",
+    dialog_cancel: "Zru\u0161it", dialog_add: "P\u0159idat",
     filter_all: "V\u0161e", filter_open: "Otev\u0159en\u00e9", filter_done: "Dokon\u010den\u00e9", filter_due_soon: "Brzy",
     ed_show_due_soon_filter: "Filtr brzy", ed_due_soon_days: "Dn\u016f dop\u0159edu", ed_hide_overdue: "Skr\u00fdt po term\u00ednu",
     progress: "{0} z {1} dokon\u010deno",
@@ -737,6 +747,7 @@ const _TRANSLATIONS = {
   da: {
     my_tasks: "Mine opgaver",
     add_placeholder: "Tilf\u00f8j ny opgave...",
+    dialog_cancel: "Annull\u00e9r", dialog_add: "Tilf\u00f8j",
     filter_all: "Alle", filter_open: "\u00c5bne", filter_done: "F\u00e6rdige", filter_due_soon: "Snart",
     ed_show_due_soon_filter: "Snart-filter", ed_due_soon_days: "Dage frem", ed_hide_overdue: "Skjul forfaldne",
     progress: "{0} af {1} f\u00e6rdige",
@@ -803,6 +814,7 @@ const _TRANSLATIONS = {
   no: {
     my_tasks: "Mine oppgaver",
     add_placeholder: "Legg til ny oppgave...",
+    dialog_cancel: "Avbryt", dialog_add: "Legg til",
     filter_all: "Alle", filter_open: "\u00c5pne", filter_done: "Ferdige", filter_due_soon: "Snart",
     ed_show_due_soon_filter: "Snart-filter", ed_due_soon_days: "Dager fremover", ed_hide_overdue: "Skjul forfalte",
     progress: "{0} av {1} ferdige",
@@ -869,6 +881,7 @@ const _TRANSLATIONS = {
   fi: {
     my_tasks: "Omat teht\u00e4v\u00e4t",
     add_placeholder: "Lis\u00e4\u00e4 uusi teht\u00e4v\u00e4...",
+    dialog_cancel: "Peruuta", dialog_add: "Lis\u00e4\u00e4",
     filter_all: "Kaikki", filter_open: "Avoimet", filter_done: "Valmiit", filter_due_soon: "Pian",
     ed_show_due_soon_filter: "Pian-suodatin", ed_due_soon_days: "P\u00e4ivi\u00e4 eteenp\u00e4in", ed_hide_overdue: "Piilota my\u00f6h\u00e4ss\u00e4 olevat",
     progress: "{0} / {1} valmis",
@@ -935,6 +948,7 @@ const _TRANSLATIONS = {
   hu: {
     my_tasks: "Feladataim",
     add_placeholder: "\u00daj feladat hozz\u00e1ad\u00e1sa...",
+    dialog_cancel: "M\u00e9gse", dialog_add: "Hozz\u00e1ad",
     filter_all: "\u00d6sszes", filter_open: "Nyitott", filter_done: "K\u00e9sz", filter_due_soon: "Hamarosan",
     ed_show_due_soon_filter: "Hamarosan sz\u0171r\u0151", ed_due_soon_days: "Napok el\u0151re", ed_hide_overdue: "Lej\u00e1rtak elrejt\u00e9se",
     progress: "{0} / {1} k\u00e9sz",
@@ -1001,6 +1015,7 @@ const _TRANSLATIONS = {
   de: {
     my_tasks: "Meine Aufgaben",
     add_placeholder: "Neue Aufgabe hinzuf\u00fcgen...",
+    dialog_cancel: "Abbrechen", dialog_add: "Hinzuf\u00fcgen",
     filter_all: "Alle",
     filter_open: "Offen",
     filter_done: "Erledigt",
@@ -2792,11 +2807,7 @@ class HomeTasksCard extends HTMLElement {
 
   _buildColumnTileGrid(filteredTasks, colIdx) {
     const col = this._config.columns[colIdx];
-
-    if (filteredTasks.length === 0) {
-      const empty = this._el("div", { className: "empty-state", textContent: this._t("empty") });
-      return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [empty]);
-    }
+    const showAdd = col.show_add_task !== false && !this._isExternalCol(colIdx);
 
     // Open tasks first, completed after
     const openTasks = filteredTasks.filter(t => !t.completed);
@@ -2804,8 +2815,61 @@ class HomeTasksCard extends HTMLElement {
     const ordered = [...openTasks, ...doneTasks];
 
     const tileEls = ordered.map(task => this._buildTaskTile(task, colIdx));
+    if (showAdd) tileEls.push(this._buildAddTaskTile(colIdx));
+
+    if (tileEls.length === 0) {
+      const empty = this._el("div", { className: "empty-state", textContent: this._t("empty") });
+      return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [empty]);
+    }
+
     const grid = this._el("div", { className: "tile-grid-inner" }, tileEls);
     return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [grid]);
+  }
+
+  _buildAddTaskTile(colIdx) {
+    const tile = this._el("div", { className: "task-tile add-tile", title: this._t("add_placeholder") });
+    tile.appendChild(this._el("div", { className: "add-tile-icon", textContent: "+" }));
+    tile.addEventListener("click", () => this._showTileAddDialog(colIdx));
+    return tile;
+  }
+
+  _showTileAddDialog(colIdx) {
+    const cs = this._columns[colIdx];
+
+    const doAdd = async () => {
+      const title = (tf.value || "").trim();
+      if (!title) return;
+      dlg.open = false;
+      cs.newTaskTitle = title;
+      await this._addTask(colIdx);
+    };
+
+    const tf = document.createElement("ha-textfield");
+    tf.setAttribute("label", this._t("add_placeholder"));
+    tf.setAttribute("dialogInitialFocus", "");
+    tf.style.width = "100%";
+    tf.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") doAdd();
+      if (e.key === "Escape") { dlg.open = false; }
+    });
+
+    const cancelBtn = document.createElement("mwc-button");
+    cancelBtn.slot = "secondaryAction";
+    cancelBtn.setAttribute("dialogAction", "close");
+    cancelBtn.textContent = this._t("dialog_cancel");
+
+    const confirmBtn = document.createElement("mwc-button");
+    confirmBtn.slot = "primaryAction";
+    confirmBtn.setAttribute("raised", "");
+    confirmBtn.textContent = this._t("dialog_add");
+    confirmBtn.addEventListener("click", doAdd);
+
+    const dlg = document.createElement("ha-dialog");
+    dlg.heading = this._t("add_placeholder");
+    dlg.open = true;
+    dlg.append(tf, cancelBtn, confirmBtn);
+    dlg.addEventListener("closed", () => dlg.remove(), { once: true });
+    document.body.appendChild(dlg);
   }
 
   _buildTaskTile(task, colIdx) {
@@ -5857,10 +5921,26 @@ class HomeTasksCard extends HTMLElement {
       }
       .tiles-mode { padding: 12px; }
 
+      /* Add-task tile */
+      .add-tile {
+        border: 2px dashed var(--todo-divider);
+        background: transparent;
+        display: flex; align-items: center; justify-content: center;
+        color: var(--secondary-text-color);
+        transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+      }
+      .add-tile:hover {
+        border-color: var(--primary-color);
+        color: var(--primary-color);
+        background: color-mix(in srgb, var(--primary-color) 8%, transparent);
+      }
+      .add-tile-icon { font-size: 2.2rem; font-weight: 300; line-height: 1; pointer-events: none; }
+
       /* Compact tile variant */
       .compact .tile-grid-inner { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 7px; }
       .compact .task-tile { border-radius: 10px; }
       .compact .tile-title { font-size: 11px; }
+      .compact .add-tile-icon { font-size: 1.8rem; }
 
       @keyframes task-exit {
         0%   { opacity: 1; transform: translateY(0); }

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -3066,7 +3066,11 @@ class HomeTasksCard extends HTMLElement {
     const cs = this._columns[colIdx];
     this.shadowRoot.querySelector(".tile-add-overlay")?.remove();
 
-    const close = () => overlay.remove();
+    const close = () => {
+      // Stop any ongoing voice recording when dialog closes
+      if (this._voiceActive.has(colIdx)) this._voiceActive.get(colIdx)();
+      overlay.remove();
+    };
     const doAdd = async () => {
       const title = input.value.trim();
       if (!title) return;
@@ -3084,6 +3088,13 @@ class HomeTasksCard extends HTMLElement {
       if (e.key === "Escape") close();
     });
 
+    const micBtn = this._el("button", {
+      className: "mic-btn tile-dialog-mic",
+      title: "Spracheingabe",
+      innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="15" height="15"><path d="M12 15c1.66 0 3-1.34 3-3V6c0-1.66-1.34-3-3-3S9 4.34 9 6v6c0 1.66 1.34 3 3 3zm-1-9c0-.55.45-1 1-1s1 .45 1 1v6c0 .55-.45 1-1 1s-1-.45-1-1V6zm6 6c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-2.08c3.39-.49 6-3.39 6-6.92h-2z"/></svg>`,
+    });
+    micBtn.addEventListener("click", () => this._startVoiceInput(colIdx, input));
+
     const cancelBtn = this._el("button", {
       className: "tile-dialog-btn tile-dialog-cancel",
       textContent: this._t("dialog_cancel"),
@@ -3096,8 +3107,9 @@ class HomeTasksCard extends HTMLElement {
     });
     confirmBtn.addEventListener("click", doAdd);
 
+    const inputRow = this._el("div", { className: "tile-dialog-input-row" }, [input, micBtn]);
     const dialog = this._el("div", { className: "tile-dialog" }, [
-      input,
+      inputRow,
       this._el("div", { className: "tile-dialog-actions" }, [cancelBtn, confirmBtn]),
     ]);
     dialog.addEventListener("click", (e) => e.stopPropagation());
@@ -6205,15 +6217,31 @@ class HomeTasksCard extends HTMLElement {
         box-shadow: 0 8px 32px rgba(0,0,0,0.4);
         display: flex; flex-direction: column; gap: 16px;
       }
+      .tile-dialog-input-row {
+        display: flex; align-items: flex-end; gap: 4px;
+        border-bottom: 2px solid var(--divider-color, rgba(255,255,255,0.12));
+      }
+      .tile-dialog-input-row:focus-within { border-bottom-color: var(--primary-color); }
       .tile-dialog-input {
-        width: 100%; box-sizing: border-box;
+        flex: 1; box-sizing: border-box;
         padding: 14px 0 10px;
-        border: none; border-bottom: 2px solid var(--divider-color, rgba(255,255,255,0.12));
+        border: none; border-bottom: none;
         background: transparent; color: var(--primary-text-color);
         font-size: 16px; font-family: inherit; outline: none;
       }
-      .tile-dialog-input:focus { border-bottom-color: var(--primary-color); }
       .tile-dialog-input::placeholder { color: var(--secondary-text-color); }
+      .tile-dialog-mic {
+        flex-shrink: 0; margin-bottom: 8px;
+        background: transparent; border: none;
+        color: var(--secondary-text-color); cursor: pointer;
+        padding: 4px; border-radius: 50%; line-height: 0;
+        transition: color 0.15s ease, background 0.15s ease;
+      }
+      .tile-dialog-mic:hover { color: var(--primary-color); background: color-mix(in srgb, var(--primary-color) 10%, transparent); }
+      .tile-dialog-mic.recording {
+        color: var(--error-color, #f44336);
+        animation: mic-pulse 1s ease-in-out infinite;
+      }
       .tile-dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
       .tile-dialog-btn {
         padding: 10px 20px; border: none; border-radius: 20px;

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -5,7 +5,7 @@
  * Security: All user-controlled content is set via textContent or DOM properties,
  * never via innerHTML with unsanitized data.
  */
-console.info("%c HOME-TASKS-CARD %c v1.13.1 ", "color: white; background: #03a9f4; font-weight: bold;", "color: #03a9f4; background: white; font-weight: bold;");
+console.info("%c HOME-TASKS-CARD %c v1.14.0 ", "color: white; background: #03a9f4; font-weight: bold;", "color: #03a9f4; background: white; font-weight: bold;");
 
 const _TRANSLATIONS = {
   en: {
@@ -115,6 +115,8 @@ const _TRANSLATIONS = {
     history: "History", history_created: "Created", history_completed: "Completed", history_reopened: "Reopened",
     history_reset: "Auto-reset (recurrence)", history_changed: "changed", history_empty: "No history yet", hist_title: "Title", history_disabled: "Disabled",
     ed_show_history: "Histories", hist_by_user: "User",
+    ed_view_mode: "View mode", ed_view_mode_list: "List", ed_view_mode_tiles: "Tiles",
+    ed_show_tile_title: "Title in tiles",
     assigned_unknown: "Unknown (%s)", recurrence_readonly: "Managed by %s", synced_with: "Synced with %s",
     due_today: "Today", due_tomorrow: "Tomorrow", due_yesterday: "Yesterday",
     due_day_after_tomorrow: "In 2 days", due_day_before_yesterday: "2 days ago",
@@ -1102,6 +1104,8 @@ const _TRANSLATIONS = {
     history: "Verlauf", history_created: "Erstellt", history_completed: "Erledigt", history_reopened: "Wieder ge\u00f6ffnet",
     history_reset: "Automatisch zur\u00fcckgesetzt", history_changed: "ge\u00e4ndert", history_empty: "Noch kein Verlauf", hist_title: "Titel", history_disabled: "Deaktiviert",
     ed_show_history: "Verläufe", hist_by_user: "Benutzer",
+    ed_view_mode: "Ansichtsmodus", ed_view_mode_list: "Liste", ed_view_mode_tiles: "Kacheln",
+    ed_show_tile_title: "Titel in Kacheln",
     assigned_unknown: "Unbekannt (%s)", recurrence_readonly: "Verwaltet von %s", synced_with: "Synchronisiert mit %s",
     due_today: "Heute", due_tomorrow: "Morgen", due_yesterday: "Gestern",
     due_day_after_tomorrow: "\u00dcbermorgen", due_day_before_yesterday: "Vorgestern",
@@ -2462,17 +2466,20 @@ class HomeTasksCard extends HTMLElement {
       ? this._el("div", { className: "person-chips-row" }, [personChips, sortBtnWrapper])
       : personChips;
 
-    const taskList = this._buildColumnTaskList(filteredTasks, colIdx);
+    const isTiles = col.view_mode === "tiles";
+    const taskList = isTiles
+      ? this._buildColumnTileGrid(filteredTasks, colIdx)
+      : this._buildColumnTaskList(filteredTasks, colIdx);
 
     const children = [];
     if (header) children.push(header);
-    children.push(addTask);
-    if (filters) children.push(filters);
-    if (tagChipsEl) children.push(tagChipsEl);
-    if (personChipsEl) children.push(personChipsEl);
+    if (!isTiles) children.push(addTask);
+    if (!isTiles && filters) children.push(filters);
+    if (!isTiles && tagChipsEl) children.push(tagChipsEl);
+    if (!isTiles && personChipsEl) children.push(personChipsEl);
     children.push(taskList);
 
-    const className = "card-column" + (col.compact === true ? " compact" : "");
+    const className = "card-column" + (col.compact === true ? " compact" : "") + (isTiles ? " tiles-mode" : "");
     return this._el("div", { className }, children);
   }
 
@@ -2779,6 +2786,74 @@ class HomeTasksCard extends HTMLElement {
       this._finishDrag();
     });
     return taskList;
+  }
+
+  // ── Tile / Kachel view ─────────────────────────────────────────────────────
+
+  _buildColumnTileGrid(filteredTasks, colIdx) {
+    const col = this._config.columns[colIdx];
+
+    if (filteredTasks.length === 0) {
+      const empty = this._el("div", { className: "empty-state", textContent: this._t("empty") });
+      return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [empty]);
+    }
+
+    // Open tasks first, completed after
+    const openTasks = filteredTasks.filter(t => !t.completed);
+    const doneTasks = filteredTasks.filter(t => t.completed);
+    const ordered = [...openTasks, ...doneTasks];
+
+    const tileEls = ordered.map(task => this._buildTaskTile(task, colIdx));
+    const grid = this._el("div", { className: "tile-grid-inner" }, tileEls);
+    return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [grid]);
+  }
+
+  _buildTaskTile(task, colIdx) {
+    const col = this._config.columns[colIdx];
+    // Use image_url if available (populated once the image feature is enabled)
+    const thumbUrl = task.image_url || null;
+
+    const cls = [
+      "task-tile",
+      task.completed ? "completed" : "",
+      thumbUrl ? "has-image" : "",
+    ].filter(Boolean).join(" ");
+
+    const tile = this._el("div", { className: cls });
+
+    if (thumbUrl) {
+      const img = this._el("img", { className: "tile-bg", src: thumbUrl, alt: "" });
+      tile.appendChild(img);
+    } else {
+      // Placeholder: first letter on gradient background
+      const placeholder = this._el("div", {
+        className: "tile-placeholder",
+        textContent: (task.title || "?").charAt(0).toUpperCase(),
+      });
+      tile.appendChild(placeholder);
+    }
+
+    // Bottom overlay: title (optional) + done badge
+    const showTitle = col.show_tile_title !== false;
+    if (showTitle || task.completed) {
+      const overlay = this._el("div", { className: "tile-overlay" });
+      if (showTitle) {
+        const titleEl = this._el("div", { className: "tile-title", textContent: task.title || "" });
+        overlay.appendChild(titleEl);
+      }
+      if (task.completed) {
+        const badge = this._el("div", { className: "tile-done-badge", textContent: "✓" });
+        overlay.appendChild(badge);
+      }
+      tile.appendChild(overlay);
+    }
+
+    // Tap anywhere on the tile = toggle complete (no detail opening)
+    tile.addEventListener("click", () => {
+      this._toggleTask(task.id, task.completed, colIdx);
+    });
+
+    return tile;
   }
 
   _buildFilterBtn(label, value, colIdx) {
@@ -5730,6 +5805,63 @@ class HomeTasksCard extends HTMLElement {
       .compact .empty-state { padding: 16px; font-size: 13px; }
       .compact .task-details-inner { padding: 8px 10px; }
 
+      /* ── Tile / Kachel view ──────────────────────────────────── */
+      .tile-grid-wrap { display: flex; flex-direction: column; gap: 12px; padding: 4px 0; }
+      .tile-grid-inner {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 10px;
+      }
+      .task-tile {
+        position: relative; border-radius: 14px; overflow: hidden;
+        aspect-ratio: 1 / 1; cursor: pointer;
+        background: var(--todo-surface);
+        border: 1px solid var(--todo-divider);
+        transition: transform 0.18s ease, box-shadow 0.18s ease;
+        user-select: none;
+      }
+      .task-tile:hover { transform: scale(1.04); box-shadow: 0 6px 18px rgba(0,0,0,0.15); }
+      .task-tile.selected { outline: 2.5px solid var(--todo-primary); outline-offset: 2px; }
+      .task-tile.completed { opacity: 0.50; }
+      .tile-bg {
+        width: 100%; height: 100%; object-fit: cover; display: block;
+        position: absolute; inset: 0;
+      }
+      .tile-placeholder {
+        width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;
+        font-size: 2.8rem; font-weight: 700; color: var(--todo-disabled);
+        background: linear-gradient(135deg, var(--todo-surface) 0%, var(--todo-divider) 100%);
+        position: absolute; inset: 0;
+      }
+      .tile-overlay {
+        position: absolute; bottom: 0; left: 0; right: 0; z-index: 2;
+        padding: 24px 9px 9px;
+        background: linear-gradient(transparent, rgba(0,0,0,0.68));
+        display: flex; align-items: flex-end; justify-content: space-between; gap: 4px;
+      }
+      .task-tile:not(.has-image) .tile-overlay {
+        background: linear-gradient(transparent, rgba(0,0,0,0.25));
+      }
+      .tile-title {
+        color: #fff; font-size: 12px; font-weight: 600; line-height: 1.3;
+        text-shadow: 0 1px 4px rgba(0,0,0,0.5);
+        display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+        flex: 1;
+      }
+      .task-tile:not(.has-image) .tile-title { color: var(--todo-text); text-shadow: none; }
+      .tile-done-badge {
+        color: #fff; font-weight: 700; flex-shrink: 0;
+        background: rgba(67,160,71,0.85); border-radius: 50%;
+        width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;
+        font-size: 11px;
+      }
+      .tiles-mode { padding: 12px; }
+
+      /* Compact tile variant */
+      .compact .tile-grid-inner { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 7px; }
+      .compact .task-tile { border-radius: 10px; }
+      .compact .tile-title { font-size: 11px; }
+
       @keyframes task-exit {
         0%   { opacity: 1; transform: translateY(0); }
         100% { opacity: 0; transform: translateY(-8px); }
@@ -6519,8 +6651,15 @@ class HomeTasksCardEditor extends HTMLElement {
           makeToggle("show-sort", "ed_show_sort", "show_sort", true),
           makeToggle("compact", "ed_compact", "compact", false),
           makeToggle("show-history", "ed_show_history", "show_history", false),
+          makeToggle("show-tile-title", "ed_show_tile_title", "show_tile_title", true),
         ]),
         sortField,
+        makeSelect(
+          "ed_view_mode",
+          [["list", "ed_view_mode_list"], ["tiles", "ed_view_mode_tiles"]],
+          col.view_mode || "list",
+          (val) => updateCol({ view_mode: val === "list" ? undefined : val })
+        ),
       ]),
       makeSection("filters", "mdi:filter-variant", "ed_sec_filters", [
         filterField,

--- a/custom_components/home_tasks/manifest.json
+++ b/custom_components/home_tasks/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/L3t4l3s/home-tasks/issues",
-  "version": "1.13.1"
+  "version": "1.14.0"
 }


### PR DESCRIPTION
## Summary

Adds a microphone button for hands-free task entry in both list view and the tile add dialog.

### How it works

1. **Primary:** HA `assist_pipeline/run` — streams raw 16 kHz PCM audio to the configured STT backend (e.g. Wyoming faster-whisper). Best accuracy, uses local/self-hosted STT.
2. **Fallback:** Web Speech API — used automatically if no STT pipeline is configured in HA.

### Config

```yaml
columns:
  - list_id: ...
    voice_lang: de-DE   # optional, defaults to HA language
```

### Visual
- 🎤 Mic icon → tap to start recording
- 🟥 Stop icon + pulse animation while recording
- Fills the input live; stops automatically on final transcript

## Stack

> ⚠️ **Stacked auf #17** — bitte `feat/task-tiles` zuerst mergen.
>
> 1. #17 `feat/task-tiles` ← zuerst
> 2. **#20 `feat/voice-input`** ← danach