### PR TITLE
feat: duplicate task and assign to another person

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,8 @@
       "mcp__ca29c868-1b25-46c6-935c-2b9f017e3af2__updateConfluencePage",
       "mcp__ca29c868-1b25-46c6-935c-2b9f017e3af2__getConfluencePage",
       "mcp__ca29c868-1b25-46c6-935c-2b9f017e3af2__getConfluencePageDescendants",
-      "mcp__ca29c868-1b25-46c6-935c-2b9f017e3af2__createConfluencePage"
+      "mcp__ca29c868-1b25-46c6-935c-2b9f017e3af2__createConfluencePage",
+      "Bash(awk 'NR>=6175 && NR<=6240' /Users/rliebi/Projects/private/home/home-tasks/custom_components/home_tasks/home-tasks-card.js)"
     ]
   }
 }

--- a/custom_components/home_tasks/const.py
+++ b/custom_components/home_tasks/const.py
@@ -33,3 +33,6 @@ VALID_NTH_WEEK = (1, 2, 3, 4, "last")
 # --- Reminders ---
 MAX_REMINDERS_PER_TASK = 5
 MAX_REMINDER_OFFSET_MINUTES = 43200  # 30 days
+
+# --- Images ---
+MAX_IMAGE_URL_LENGTH = 2048

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -1215,7 +1215,6 @@ class HomeTasksCard extends HTMLElement {
     this._weekPatternOverride = new Map();   // task.id → "on"
     this._yearPatternOverride = new Map();   // task.id → "on"
     this._generatingImage = new Set();       // task IDs currently generating
-    this._mediaSelectorOpen = new Set();     // task IDs with media selector visible
   }
 
   _defaultColState() {
@@ -1284,13 +1283,10 @@ class HomeTasksCard extends HTMLElement {
       const taskStillExists = this._columns.some(cs => cs.tasks?.some(t => t.id === this._editingTaskId));
       if (!taskStillExists) this._editingTaskId = null;
     }
-    // _expandedTasks / _mediaSelectorOpen: clean up IDs no longer in any column
+    // Clean up expanded task IDs no longer in any column
     const allTaskIds = new Set(this._columns.flatMap(cs => (cs.tasks || []).map(t => t.id)));
     for (const id of this._expandedTasks) {
       if (!allTaskIds.has(id)) this._expandedTasks.delete(id);
-    }
-    for (const id of this._mediaSelectorOpen) {
-      if (!allTaskIds.has(id)) this._mediaSelectorOpen.delete(id);
     }
 
     // Reset per-column filter/sort when list or defaults change
@@ -5002,65 +4998,21 @@ class HomeTasksCard extends HTMLElement {
   }
 
   _openMediaPicker(task, colIdx) {
-    const dialogTag = "dialog-media-player-browse";
-    if (customElements.get(dialogTag)) {
-      // Element already registered — open HA's native media browser dialog.
-      this.dispatchEvent(new CustomEvent("show-dialog", {
-        bubbles: true,
-        composed: true,
-        detail: {
-          dialogTag,
-          dialogImport: () => Promise.resolve(),
-          dialogParams: {
-            action: "pick",
-            navigateIds: [{ params: {}, id: "media-source://media_source" }],
-            mediaPickedCallback: (item) => {
-              const url = item?.media_content_id;
-              if (url) this._saveImageUrl(task, colIdx, url);
-            },
+    this.dispatchEvent(new CustomEvent("show-dialog", {
+      bubbles: true,
+      composed: true,
+      detail: {
+        dialogTag: "dialog-media-player-browse",
+        dialogParams: {
+          action: "pick",
+          navigateIds: [{ params: {}, id: "media-source://media_source" }],
+          mediaPickedCallback: (item) => {
+            const url = item?.media_content_id;
+            if (url) this._saveImageUrl(task, colIdx, url);
           },
         },
-      }));
-    } else {
-      // Element not yet lazy-loaded — show a URL-input fallback overlay.
-      this._openMediaUrlFallback(task, colIdx);
-    }
-  }
-
-  _openMediaUrlFallback(task, colIdx) {
-    this.shadowRoot.querySelector(".media-url-overlay")?.remove();
-    const input = this._el("input", {
-      type: "url", className: "tile-dialog-input",
-      placeholder: "media-source:// oder https://…",
-    });
-    const cancelBtn = this._el("button", {
-      className: "tile-dialog-btn tile-dialog-cancel",
-      textContent: this._t("dialog_cancel"), type: "button",
-    });
-    const confirmBtn = this._el("button", {
-      className: "tile-dialog-btn tile-dialog-confirm",
-      textContent: "OK", type: "button",
-    });
-    const close = () => overlay.remove();
-    cancelBtn.addEventListener("click", close);
-    confirmBtn.addEventListener("click", () => {
-      const url = input.value.trim();
-      if (url) this._saveImageUrl(task, colIdx, url);
-      close();
-    });
-    input.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") confirmBtn.click();
-      if (e.key === "Escape") close();
-    });
-    const dialog = this._el("div", { className: "tile-dialog" }, [
-      input,
-      this._el("div", { className: "tile-dialog-actions" }, [cancelBtn, confirmBtn]),
-    ]);
-    dialog.addEventListener("click", (e) => e.stopPropagation());
-    const overlay = this._el("div", { className: "media-url-overlay tile-add-overlay" }, [dialog]);
-    overlay.addEventListener("click", close);
-    this.shadowRoot.appendChild(overlay);
-    requestAnimationFrame(() => input.focus());
+      },
+    }));
   }
 
   async _generateTaskImage(task, colIdx, force = false) {

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -4996,25 +4996,65 @@ class HomeTasksCard extends HTMLElement {
   }
 
   _openMediaPicker(task, colIdx) {
-    // Open HA's native media browser dialog via the show-dialog event.
-    // composed:true lets the event cross shadow DOM boundaries up to
-    // the top-level <home-assistant> element which handles show-dialog.
-    this.dispatchEvent(new CustomEvent("show-dialog", {
-      bubbles: true,
-      composed: true,
-      detail: {
-        dialogTag: "ha-media-player-browse-dialog",
-        dialogImport: () => customElements.whenDefined("ha-media-player-browse-dialog"),
-        dialogParams: {
-          action: "pick",
-          navigateIds: [{ params: {}, id: "media-source://media_source" }],
-          mediaPickedCallback: (item) => {
-            const url = item?.media_content_id;
-            if (url) this._saveImageUrl(task, colIdx, url);
+    const dialogTag = "dialog-media-player-browse";
+    if (customElements.get(dialogTag)) {
+      // Element already registered — open HA's native media browser dialog.
+      this.dispatchEvent(new CustomEvent("show-dialog", {
+        bubbles: true,
+        composed: true,
+        detail: {
+          dialogTag,
+          dialogImport: () => Promise.resolve(),
+          dialogParams: {
+            action: "pick",
+            navigateIds: [{ params: {}, id: "media-source://media_source" }],
+            mediaPickedCallback: (item) => {
+              const url = item?.media_content_id;
+              if (url) this._saveImageUrl(task, colIdx, url);
+            },
           },
         },
-      },
-    }));
+      }));
+    } else {
+      // Element not yet lazy-loaded — show a URL-input fallback overlay.
+      this._openMediaUrlFallback(task, colIdx);
+    }
+  }
+
+  _openMediaUrlFallback(task, colIdx) {
+    this.shadowRoot.querySelector(".media-url-overlay")?.remove();
+    const input = this._el("input", {
+      type: "url", className: "tile-dialog-input",
+      placeholder: "media-source:// oder https://…",
+    });
+    const cancelBtn = this._el("button", {
+      className: "tile-dialog-btn tile-dialog-cancel",
+      textContent: this._t("dialog_cancel"), type: "button",
+    });
+    const confirmBtn = this._el("button", {
+      className: "tile-dialog-btn tile-dialog-confirm",
+      textContent: "OK", type: "button",
+    });
+    const close = () => overlay.remove();
+    cancelBtn.addEventListener("click", close);
+    confirmBtn.addEventListener("click", () => {
+      const url = input.value.trim();
+      if (url) this._saveImageUrl(task, colIdx, url);
+      close();
+    });
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") confirmBtn.click();
+      if (e.key === "Escape") close();
+    });
+    const dialog = this._el("div", { className: "tile-dialog" }, [
+      input,
+      this._el("div", { className: "tile-dialog-actions" }, [cancelBtn, confirmBtn]),
+    ]);
+    dialog.addEventListener("click", (e) => e.stopPropagation());
+    const overlay = this._el("div", { className: "media-url-overlay tile-add-overlay" }, [dialog]);
+    overlay.addEventListener("click", close);
+    this.shadowRoot.appendChild(overlay);
+    requestAnimationFrame(() => input.focus());
   }
 
   async _generateTaskImage(task, colIdx, force = false) {

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -141,6 +141,7 @@ const _TRANSLATIONS = {
     ed_preset_assignees: "Limit to assignees",
     ed_preset_labels: "Limit to tags",
     ed_ms_add: "Add…",
+    ed_ai_image_section: "AI Image Generation",
     ed_ai_image_entity: "AI entity for image generation",
     ed_ai_image_entity_placeholder: "e.g. ai_task.openai",
     ed_ai_prompt_prefix: "Prompt prefix (optional)",
@@ -1149,6 +1150,7 @@ const _TRANSLATIONS = {
     ed_preset_assignees: "Auf Personen begrenzen",
     ed_preset_labels: "Auf Tags begrenzen",
     ed_ms_add: "Hinzufügen…",
+    ed_ai_image_section: "KI-Bildgenerierung",
     ed_ai_image_entity: "KI-Entität für Bildgenerierung",
     ed_ai_image_entity_placeholder: "z.B. ai_task.openai",
     ed_ai_prompt_prefix: "Prompt-Präfix (optional)",
@@ -6508,15 +6510,12 @@ class HomeTasksCardEditor extends HTMLElement {
       :host { display: block; }
       .editor { display: flex; flex-direction: column; gap: 0; padding: 16px 0; }
       .editor-card-title-row { margin-bottom: 12px; }
-      .editor-imggen-row { display: flex; gap: 12px; }
-      .editor-imggen-field { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
-      .editor-field-label { font-size: 12px; color: var(--secondary-text-color); }
-      .editor-native-select, .editor-native-input {
+      .editor-native-select {
         width: 100%; box-sizing: border-box; padding: 8px;
         background: var(--card-background-color); color: var(--primary-text-color);
         border: 1px solid var(--divider-color); border-radius: 4px; font-size: 14px;
       }
-      .editor-native-select:focus, .editor-native-input:focus {
+      .editor-native-select:focus {
         outline: none; border-color: var(--primary-color);
       }
       .editor-tabs-row {
@@ -6630,39 +6629,6 @@ class HomeTasksCardEditor extends HTMLElement {
     });
     const cardTitleRow = this._el("div", { className: "editor-card-title-row" }, [cardTitleInput]);
 
-    const imgGen = this._config.image_generation || {};
-    const updateImgGen = (patch) => {
-      const merged = { ...imgGen, ...patch };
-      Object.keys(merged).forEach(k => merged[k] === undefined && delete merged[k]);
-      this._config = { ...this._config, image_generation: Object.keys(merged).length ? merged : undefined };
-      this._fireChanged();
-    };
-
-    // Entity dropdown — native <select> + prompt prefix input
-    const aiEntities = Object.keys(this._hass?.states || {}).filter(e => e.startsWith("ai_task.")).sort();
-    const aiEntitySelect = this._el("select", { className: "editor-native-select" });
-    aiEntitySelect.appendChild(this._el("option", { value: "", textContent: "— Auto-detect —" }));
-    for (const eid of aiEntities) aiEntitySelect.appendChild(this._el("option", { value: eid, textContent: eid }));
-    aiEntitySelect.value = imgGen.entity_id || "";
-    aiEntitySelect.addEventListener("change", (e) => updateImgGen({ entity_id: e.target.value || undefined }));
-
-    const promptInput = this._el("input", {
-      type: "text", className: "editor-native-input",
-      placeholder: this._t("ed_ai_prompt_prefix_placeholder"),
-      value: imgGen.prompt_prefix || "",
-    });
-    promptInput.addEventListener("change", (e) => updateImgGen({ prompt_prefix: e.target.value.trim() || undefined }));
-
-    const aiEntityRow = this._el("div", { className: "editor-card-title-row editor-imggen-row" }, [
-      this._el("div", { className: "editor-imggen-field" }, [
-        this._el("span", { className: "editor-field-label", textContent: this._t("ed_ai_image_entity") }),
-        aiEntitySelect,
-      ]),
-      this._el("div", { className: "editor-imggen-field" }, [
-        this._el("span", { className: "editor-field-label", textContent: this._t("ed_ai_prompt_prefix") }),
-        promptInput,
-      ]),
-    ]);
 
     // Tab bar (tabs on left, + on right)
     const tabsEl = this._el("div", { className: "editor-tabs" });
@@ -6774,8 +6740,59 @@ class HomeTasksCardEditor extends HTMLElement {
       ? this._buildCodeEditor(activeTab)
       : this._buildVisualEditor(activeTab);
 
-    const editor = this._el("div", { className: "editor" }, [cardTitleRow, aiEntityRow, tabsRow, controls, tabContent]);
+    const imgGenSection = this._buildImgGenSection();
+    const editor = this._el("div", { className: "editor" }, [cardTitleRow, tabsRow, controls, tabContent, imgGenSection]);
     root.appendChild(editor);
+  }
+
+  _buildImgGenSection() {
+    const imgGen = this._config.image_generation || {};
+    const updateImgGen = (patch) => {
+      const merged = { ...imgGen, ...patch };
+      Object.keys(merged).forEach(k => merged[k] === undefined && delete merged[k]);
+      this._config = { ...this._config, image_generation: Object.keys(merged).length ? merged : undefined };
+      this._fireChanged();
+    };
+
+    const entityPicker = document.createElement("ha-entity-picker");
+    entityPicker.hass = this._hass;
+    entityPicker.label = this._t("ed_ai_image_entity");
+    entityPicker.value = imgGen.entity_id || "";
+    entityPicker.includeDomains = ["ai_task"];
+    entityPicker.allowCustomEntity = true;
+    entityPicker.style.width = "100%";
+    entityPicker.addEventListener("value-changed", (e) => {
+      updateImgGen({ entity_id: e.detail.value || undefined });
+    });
+
+    const promptField = document.createElement("ha-textfield");
+    promptField.label = this._t("ed_ai_prompt_prefix");
+    promptField.placeholder = this._t("ed_ai_prompt_prefix_placeholder");
+    promptField.value = imgGen.prompt_prefix || "";
+    promptField.style.width = "100%";
+    promptField.addEventListener("change", (e) => {
+      updateImgGen({ prompt_prefix: e.target.value.trim() || undefined });
+    });
+
+    const det = document.createElement("details");
+    if (this._sectionOpen?.imggen) det.open = true;
+    det.addEventListener("toggle", () => {
+      this._sectionOpen = { ...(this._sectionOpen || {}), imggen: det.open };
+    });
+    const sum = document.createElement("summary");
+    sum.className = "editor-section-summary";
+    const ico = document.createElement("ha-icon");
+    ico.setAttribute("icon", "mdi:image-spark");
+    ico.style.cssText = "--mdc-icon-size:20px;width:20px;height:20px;flex-shrink:0;";
+    const lbl = this._el("span", { textContent: this._t("ed_ai_image_section"), style: "flex:1" });
+    const chev = document.createElement("ha-icon");
+    chev.setAttribute("icon", "mdi:chevron-down");
+    chev.className = "sum-chevron";
+    chev.style.cssText = "--mdc-icon-size:20px;width:20px;height:20px;";
+    sum.append(ico, lbl, chev);
+    det.appendChild(sum);
+    det.appendChild(this._el("div", { className: "section-content" }, [entityPicker, promptField]));
+    return det;
   }
 
   _buildCodeEditor(tabIdx) {

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -2835,41 +2835,49 @@ class HomeTasksCard extends HTMLElement {
 
   _showTileAddDialog(colIdx) {
     const cs = this._columns[colIdx];
+    this.shadowRoot.querySelector(".tile-add-overlay")?.remove();
 
+    const close = () => overlay.remove();
     const doAdd = async () => {
-      const title = (tf.value || "").trim();
+      const title = input.value.trim();
       if (!title) return;
-      dlg.open = false;
+      close();
       cs.newTaskTitle = title;
       await this._addTask(colIdx);
     };
 
-    const tf = document.createElement("ha-textfield");
-    tf.setAttribute("label", this._t("add_placeholder"));
-    tf.setAttribute("dialogInitialFocus", "");
-    tf.style.width = "100%";
-    tf.addEventListener("keydown", (e) => {
+    const input = this._el("input", {
+      type: "text", className: "tile-dialog-input",
+      placeholder: this._t("add_placeholder"),
+    });
+    input.addEventListener("keydown", (e) => {
       if (e.key === "Enter") doAdd();
-      if (e.key === "Escape") { dlg.open = false; }
+      if (e.key === "Escape") close();
     });
 
-    const cancelBtn = document.createElement("mwc-button");
-    cancelBtn.slot = "secondaryAction";
-    cancelBtn.setAttribute("dialogAction", "close");
-    cancelBtn.textContent = this._t("dialog_cancel");
+    const cancelBtn = this._el("button", {
+      className: "tile-dialog-btn tile-dialog-cancel",
+      textContent: this._t("dialog_cancel"),
+    });
+    cancelBtn.addEventListener("click", close);
 
-    const confirmBtn = document.createElement("mwc-button");
-    confirmBtn.slot = "primaryAction";
-    confirmBtn.setAttribute("raised", "");
-    confirmBtn.textContent = this._t("dialog_add");
+    const confirmBtn = this._el("button", {
+      className: "tile-dialog-btn tile-dialog-confirm",
+      textContent: this._t("dialog_add"),
+    });
     confirmBtn.addEventListener("click", doAdd);
 
-    const dlg = document.createElement("ha-dialog");
-    dlg.heading = this._t("add_placeholder");
-    dlg.open = true;
-    dlg.append(tf, cancelBtn, confirmBtn);
-    dlg.addEventListener("closed", () => dlg.remove(), { once: true });
-    document.body.appendChild(dlg);
+    const dialog = this._el("div", { className: "tile-dialog" }, [
+      input,
+      this._el("div", { className: "tile-dialog-actions" }, [cancelBtn, confirmBtn]),
+    ]);
+    dialog.addEventListener("click", (e) => e.stopPropagation());
+
+    const overlay = this._el("div", { className: "tile-add-overlay" }, [dialog]);
+    overlay.addEventListener("click", close);
+
+    this.shadowRoot.appendChild(overlay);
+    requestAnimationFrame(() => input.focus());
   }
 
   _buildTaskTile(task, colIdx) {
@@ -5935,6 +5943,38 @@ class HomeTasksCard extends HTMLElement {
         background: color-mix(in srgb, var(--primary-color) 8%, transparent);
       }
       .add-tile-icon { font-size: 2.2rem; font-weight: 300; line-height: 1; pointer-events: none; }
+
+      /* Add-task dialog overlay */
+      .tile-add-overlay {
+        position: fixed; inset: 0; z-index: 9999;
+        background: rgba(0,0,0,0.42);
+        display: flex; align-items: center; justify-content: center;
+      }
+      .tile-dialog {
+        background: var(--ha-card-background, var(--card-background-color, #1c1c1c));
+        border-radius: 28px; padding: 24px 24px 16px;
+        min-width: 280px; max-width: min(420px, 90vw);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+        display: flex; flex-direction: column; gap: 16px;
+      }
+      .tile-dialog-input {
+        width: 100%; box-sizing: border-box;
+        padding: 14px 0 10px;
+        border: none; border-bottom: 2px solid var(--divider-color, rgba(255,255,255,0.12));
+        background: transparent; color: var(--primary-text-color);
+        font-size: 16px; font-family: inherit; outline: none;
+      }
+      .tile-dialog-input:focus { border-bottom-color: var(--primary-color); }
+      .tile-dialog-input::placeholder { color: var(--secondary-text-color); }
+      .tile-dialog-actions { display: flex; justify-content: flex-end; gap: 8px; }
+      .tile-dialog-btn {
+        padding: 10px 20px; border: none; border-radius: 20px;
+        font-size: 14px; font-weight: 500; font-family: inherit; cursor: pointer;
+      }
+      .tile-dialog-cancel { background: transparent; color: var(--primary-color); }
+      .tile-dialog-cancel:hover { background: color-mix(in srgb, var(--primary-color) 10%, transparent); }
+      .tile-dialog-confirm { background: var(--primary-color); color: var(--text-primary-color, #fff); }
+      .tile-dialog-confirm:hover { filter: brightness(1.08); }
 
       /* Compact tile variant */
       .compact .tile-grid-inner { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 7px; }

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -5100,50 +5100,59 @@ class HomeTasksCard extends HTMLElement {
         const crumb = this._el("div", { className: "mb-crumb", textContent: data.title || "Medien" });
         list.appendChild(crumb);
 
-        for (const item of (data.children || [])) {
+        const children = data.children || [];
+        const folders = children.filter(i => i.can_expand);
+        const files = children.filter(i => !i.can_expand);
+
+        const pickFile = async (item) => {
+          try {
+            const resolved = await this._hass.callWS({
+              type: "media_source/resolve_media",
+              media_content_id: item.media_content_id,
+            });
+            await this._saveImageUrl(task, colIdx, resolved.url || item.thumbnail);
+          } catch {
+            if (item.thumbnail) await this._saveImageUrl(task, colIdx, item.thumbnail);
+          }
+          dialog.close();
+          dialog.remove();
+        };
+
+        for (const item of folders) {
           const row = document.createElement("button");
-          row.className = "mb-item" + (item.can_expand ? " mb-folder" : "");
-
-          if (item.thumbnail) {
-            const img = this._el("img", { className: "mb-thumb", src: item.thumbnail, alt: "" });
-            row.appendChild(img);
-          } else {
-            const ico = document.createElement("ha-icon");
-            const iconMap = { directory: "mdi:folder", image: "mdi:image", music: "mdi:music-note", video: "mdi:video" };
-            ico.setAttribute("icon", iconMap[item.media_class] || "mdi:file");
-            ico.style.cssText = "--mdc-icon-size:24px;flex-shrink:0;color:var(--secondary-text-color);";
-            row.appendChild(ico);
-          }
-
+          row.className = "mb-item mb-folder";
+          const ico = document.createElement("ha-icon");
+          const iconMap = { directory: "mdi:folder", image: "mdi:folder-image", music: "mdi:folder-music", video: "mdi:folder-play" };
+          ico.setAttribute("icon", iconMap[item.media_class] || "mdi:folder");
+          ico.style.cssText = "--mdc-icon-size:24px;flex-shrink:0;color:var(--secondary-text-color);";
+          row.appendChild(ico);
           row.appendChild(this._el("span", { className: "mb-item-title", textContent: item.title }));
-
-          if (item.can_expand) {
-            const chev = document.createElement("ha-icon");
-            chev.setAttribute("icon", "mdi:chevron-right");
-            chev.style.cssText = "--mdc-icon-size:18px;flex-shrink:0;color:var(--secondary-text-color);";
-            row.appendChild(chev);
-          }
-
-          row.addEventListener("click", async () => {
-            if (item.can_expand) {
-              navStack.push({ id, title: data.title || "Zurück" });
-              await load(item.media_content_id);
-            } else {
-              try {
-                const resolved = await this._hass.callWS({
-                  type: "media_source/resolve_media",
-                  media_content_id: item.media_content_id,
-                });
-                await this._saveImageUrl(task, colIdx, resolved.url || item.thumbnail);
-              } catch {
-                if (item.thumbnail) await this._saveImageUrl(task, colIdx, item.thumbnail);
-              }
-              dialog.close();
-              dialog.remove();
-            }
-          });
-
+          const chev = document.createElement("ha-icon");
+          chev.setAttribute("icon", "mdi:chevron-right");
+          chev.style.cssText = "--mdc-icon-size:18px;flex-shrink:0;color:var(--secondary-text-color);";
+          row.appendChild(chev);
+          row.addEventListener("click", () => { navStack.push({ id, title: data.title || "Zurück" }); load(item.media_content_id); });
           list.appendChild(row);
+        }
+
+        if (files.length > 0) {
+          const grid = this._el("div", { className: "mb-grid" });
+          for (const item of files) {
+            const cell = document.createElement("button");
+            cell.className = "mb-grid-item";
+            if (item.thumbnail) {
+              cell.appendChild(this._el("img", { className: "mb-grid-thumb", src: item.thumbnail, alt: item.title }));
+            } else {
+              const ico = document.createElement("ha-icon");
+              ico.setAttribute("icon", "mdi:image");
+              ico.style.cssText = "--mdc-icon-size:40px;color:var(--secondary-text-color);";
+              cell.appendChild(ico);
+            }
+            cell.appendChild(this._el("span", { className: "mb-grid-title", textContent: item.title }));
+            cell.addEventListener("click", () => pickFile(item));
+            grid.appendChild(cell);
+          }
+          list.appendChild(grid);
         }
 
         if (!data.children?.length) {
@@ -6453,6 +6462,24 @@ class HomeTasksCard extends HTMLElement {
       }
       .mb-thumb { width: 40px; height: 40px; object-fit: cover; border-radius: 4px; flex-shrink: 0; }
       .mb-item-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .mb-grid {
+        display: grid; grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+        gap: 8px; padding: 8px;
+      }
+      .mb-grid-item {
+        display: flex; flex-direction: column; align-items: center; gap: 5px;
+        background: none; border: none; cursor: pointer; padding: 6px; border-radius: 8px;
+        font-family: inherit;
+      }
+      .mb-grid-item:hover { background: var(--secondary-background-color, rgba(0,0,0,0.06)); }
+      .mb-grid-thumb {
+        width: 100%; aspect-ratio: 1 / 1; object-fit: cover; border-radius: 6px;
+        display: block;
+      }
+      .mb-grid-title {
+        font-size: 11px; color: var(--secondary-text-color); width: 100%;
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: center;
+      }
 
       /* Compact tile variant */
       .compact .tile-grid-inner { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 7px; }

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -141,6 +141,8 @@ const _TRANSLATIONS = {
     ed_preset_assignees: "Limit to assignees",
     ed_preset_labels: "Limit to tags",
     ed_ms_add: "Add…",
+    ed_ai_image_entity: "AI entity for image generation",
+    ed_ai_image_entity_placeholder: "e.g. ai_task.openai",
   },
   nl: {
     my_tasks: "Mijn taken",
@@ -1145,6 +1147,8 @@ const _TRANSLATIONS = {
     ed_preset_assignees: "Auf Personen begrenzen",
     ed_preset_labels: "Auf Tags begrenzen",
     ed_ms_add: "Hinzufügen…",
+    ed_ai_image_entity: "KI-Entität für Bildgenerierung",
+    ed_ai_image_entity_placeholder: "z.B. ai_task.openai",
   },
 };
 
@@ -5026,9 +5030,8 @@ class HomeTasksCard extends HTMLElement {
       task_id: task.id,
       force: force,
     };
-    // prompt_prefix is the only card-level config; model/key/quality are
-    // handled by the ai_task integration on the server side.
     if (imgCfg.prompt_prefix) payload.prompt_prefix = imgCfg.prompt_prefix;
+    if (imgCfg.entity_id) payload.entity_id = imgCfg.entity_id;
 
     try {
       const result = await this._hass.callWS(payload);
@@ -6572,6 +6575,18 @@ class HomeTasksCardEditor extends HTMLElement {
     });
     const cardTitleRow = this._el("div", { className: "editor-card-title-row" }, [cardTitleInput]);
 
+    const aiEntityInput = document.createElement("ha-textfield");
+    aiEntityInput.label = this._t("ed_ai_image_entity");
+    aiEntityInput.placeholder = this._t("ed_ai_image_entity_placeholder");
+    aiEntityInput.value = (this._config.image_generation || {}).entity_id || "";
+    aiEntityInput.style.width = "100%";
+    aiEntityInput.addEventListener("change", (e) => {
+      const val = e.target.value.trim() || undefined;
+      this._config = { ...this._config, image_generation: { ...(this._config.image_generation || {}), entity_id: val } };
+      this._fireChanged();
+    });
+    const aiEntityRow = this._el("div", { className: "editor-card-title-row" }, [aiEntityInput]);
+
     // Tab bar (tabs on left, + on right)
     const tabsEl = this._el("div", { className: "editor-tabs" });
     for (let i = 0; i < cols.length; i++) {
@@ -6682,7 +6697,7 @@ class HomeTasksCardEditor extends HTMLElement {
       ? this._buildCodeEditor(activeTab)
       : this._buildVisualEditor(activeTab);
 
-    const editor = this._el("div", { className: "editor" }, [cardTitleRow, tabsRow, controls, tabContent]);
+    const editor = this._el("div", { className: "editor" }, [cardTitleRow, aiEntityRow, tabsRow, controls, tabContent]);
     root.appendChild(editor);
   }
 

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -116,6 +116,7 @@ const _TRANSLATIONS = {
     history: "History", history_created: "Created", history_completed: "Completed", history_reopened: "Reopened",
     history_reset: "Auto-reset (recurrence)", history_changed: "changed", history_empty: "No history yet", hist_title: "Title", history_disabled: "Disabled",
     ed_show_history: "Histories", hist_by_user: "User",
+    ed_show_images: "Images",
     ed_view_mode: "View mode", ed_view_mode_list: "List", ed_view_mode_tiles: "Tiles",
     ed_show_tile_title: "Title in tiles",
     assigned_unknown: "Unknown (%s)", recurrence_readonly: "Managed by %s", synced_with: "Synced with %s",
@@ -1119,6 +1120,7 @@ const _TRANSLATIONS = {
     history: "Verlauf", history_created: "Erstellt", history_completed: "Erledigt", history_reopened: "Wieder ge\u00f6ffnet",
     history_reset: "Automatisch zur\u00fcckgesetzt", history_changed: "ge\u00e4ndert", history_empty: "Noch kein Verlauf", hist_title: "Titel", history_disabled: "Deaktiviert",
     ed_show_history: "Verläufe", hist_by_user: "Benutzer",
+    ed_show_images: "Bilder",
     ed_view_mode: "Ansichtsmodus", ed_view_mode_list: "Liste", ed_view_mode_tiles: "Kacheln",
     ed_show_tile_title: "Titel in Kacheln",
     assigned_unknown: "Unbekannt (%s)", recurrence_readonly: "Verwaltet von %s", synced_with: "Synchronisiert mit %s",
@@ -1174,6 +1176,7 @@ class HomeTasksCard extends HTMLElement {
     // Per-column state: [{filter, sortBy, sortOpen, tagFilters, personFilters, tasks, newTaskTitle}]
     this._columns = [];
     this._expandedTasks = new Set();
+    this._uploadingImage = new Set();
     this._editingTaskId = null;
     this._editingSubTaskId = null;
     this._draggedTaskId = null;
@@ -2883,8 +2886,8 @@ class HomeTasksCard extends HTMLElement {
 
   _buildTaskTile(task, colIdx) {
     const col = this._config.columns[colIdx];
-    // Use image_url if available (populated once the image feature is enabled)
-    const thumbUrl = task.image_url || null;
+    const showImages = col.show_images === true;
+    const thumbUrl = showImages ? (this._thumbUrl(task.image_url) || task.image_url) : null;
 
     const cls = [
       "task-tile",
@@ -2894,6 +2897,7 @@ class HomeTasksCard extends HTMLElement {
 
     const tile = this._el("div", { className: cls });
 
+    // Background image (only when show_images is enabled)
     if (thumbUrl) {
       const img = this._el("img", { className: "tile-bg", src: thumbUrl, alt: "" });
       tile.appendChild(img);
@@ -2922,7 +2926,7 @@ class HomeTasksCard extends HTMLElement {
     }
 
     // Tap anywhere on the tile = toggle complete (no detail opening)
-    tile.addEventListener("click", () => {
+    tile.addEventListener("click", (e) => {
       this._toggleTask(task.id, task.completed, colIdx);
     });
 
@@ -3215,10 +3219,10 @@ class HomeTasksCard extends HTMLElement {
     const expandBtn = this._buildTaskExpandButton(isExpanded);
 
     const mainRowChildren = [checkboxEl, contentEl];
-    if (task.image_url && !isEditing) {
+    if (task.image_url && !isEditing && col.show_images === true) {
       const thumb = this._el("img", {
         className: "task-thumb",
-        src: task.image_url,
+        src: this._thumbUrl(task.image_url) || task.image_url,
         alt: "",
         title: task.title,
       });
@@ -3292,6 +3296,13 @@ class HomeTasksCard extends HTMLElement {
       children.push(titleSpan);
     }
     return children;
+  }
+
+  // Returns the thumbnail URL for a task image (300×300 JPEG).
+  // Falls back to the full image URL if no thumbnail exists yet.
+  _thumbUrl(imageUrl) {
+    if (!imageUrl) return null;
+    return imageUrl.replace(/\/task_([a-f0-9]+)\.png(\?.*)?$/, '/task_$1_thumb.jpg');
   }
 
   _buildTaskExpandButton(isExpanded) {
@@ -3597,7 +3608,7 @@ class HomeTasksCard extends HTMLElement {
     if (col.show_reminders !== false) details.push(this._buildRemindersSection(task, colIdx));
     if (col.show_recurrence !== false) details.push(this._buildRecurrenceSection(task, colIdx));
     if (col.show_history) details.push(this._buildHistorySection(task));
-    if (!this._isExternalCol(colIdx)) details.push(this._buildImageSection(task, colIdx));
+    if (!this._isExternalCol(colIdx) && col.show_images === true) details.push(this._buildImageSection(task, colIdx));
     details.push(this._buildActionsSection(task, colIdx));
 
     const inner = this._el("div", { className: "task-details-inner" }, details);
@@ -4919,44 +4930,78 @@ class HomeTasksCard extends HTMLElement {
       imgWrap.appendChild(img);
 
       // Remove image button (×)
-      const removeBtn = this._el("button", {
-        className: "task-image-remove",
-        title: "Bild entfernen",
-        innerHTML: "×",
-      });
+      const removeBtn = this._el("button", { className: "task-image-remove", title: "Bild entfernen" });
+      removeBtn.innerHTML = `<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>`;
       removeBtn.addEventListener("click", async () => {
-        await this._hass.callWS({
-          type: "home_tasks/update_task",
-          entry_id: col.entry_id,
-          task_id: task.id,
-          image_url: null,
-        });
+        try {
+          await this._hass.callWS({
+            type: "home_tasks/update_task",
+            list_id: col.list_id,
+            task_id: task.id,
+            image_url: null,
+          });
+          const cs = this._columns[colIdx];
+          if (cs && cs.tasks) {
+            const idx = cs.tasks.findIndex(t => t.id === task.id);
+            if (idx >= 0) cs.tasks[idx] = { ...cs.tasks[idx], image_url: null };
+          }
+        } catch (err) {
+          console.error("Failed to remove image:", err);
+          alert("Bild entfernen fehlgeschlagen: " + (err.message || err));
+        }
         this._render();
       });
       imgWrap.appendChild(removeBtn);
       children.push(imgWrap);
     }
 
-    // --- Generate button ---
+    // --- Action buttons row ---
+    const isUploading = this._uploadingImage && this._uploadingImage.has(task.id);
+    const busy = isGenerating || isUploading;
+
+    // Generate button
     const genBtn = this._el("button", {
-      className: "generate-image-btn" + (isGenerating ? " generating" : ""),
-      disabled: isGenerating,
+      className: "generate-image-btn" + (busy ? " generating" : ""),
+      disabled: busy,
     });
     if (isGenerating) {
       genBtn.innerHTML = `<span class="spinner"></span> Generiere…`;
     } else {
-      genBtn.innerHTML = `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right:6px;vertical-align:-3px"><path d="M12 2a10 10 0 100 20A10 10 0 0012 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>${task.image_url ? "Bild neu generieren" : "✨ Bild generieren"}`;
+      genBtn.innerHTML = `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right:6px;vertical-align:-3px"><path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-1 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/></svg>${task.image_url ? "Neu generieren" : "✨ Generieren"}`;
     }
-    genBtn.addEventListener("click", () => this._generateTaskImage(task, colIdx));
+    genBtn.addEventListener("click", () => this._generateTaskImage(task, colIdx, !!task.image_url));
     children.push(genBtn);
+
+    // Upload button + hidden file input
+    const uploadBtn = this._el("button", {
+      className: "generate-image-btn" + (busy ? " generating" : ""),
+      disabled: busy,
+    });
+    if (isUploading) {
+      uploadBtn.innerHTML = `<span class="spinner"></span> Lade hoch…`;
+    } else {
+      uploadBtn.innerHTML = `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right:6px;vertical-align:-3px"><path d="M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z"/></svg>Hochladen`;
+    }
+    const fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.accept = "image/*";
+    fileInput.style.display = "none";
+    fileInput.addEventListener("change", () => {
+      const file = fileInput.files[0];
+      if (file) this._uploadTaskImage(task, colIdx, file);
+      fileInput.value = "";
+    });
+    uploadBtn.addEventListener("click", () => fileInput.click());
+    children.push(uploadBtn);
 
     return this._el("div", { className: "detail-section detail-section--image" }, [
       this._el("label", { className: "detail-label", textContent: "Bild" }),
       this._el("div", { className: "image-section-body" }, children),
+      fileInput,
     ]);
   }
 
-  async _generateTaskImage(task, colIdx) {
+  async _generateTaskImage(task, colIdx, force = false) {
     const col = this._config.columns[colIdx];
     const imgCfg = this._config.image_generation || {};
 
@@ -4965,8 +5010,9 @@ class HomeTasksCard extends HTMLElement {
 
     const payload = {
       type: "home_tasks/generate_task_image",
-      entry_id: col.entry_id,
+      entry_id: col.list_id,
       task_id: task.id,
+      force: force,
     };
     if (imgCfg.api_key) payload.api_key = imgCfg.api_key;
     if (imgCfg.endpoint) payload.endpoint = imgCfg.endpoint;
@@ -4988,6 +5034,51 @@ class HomeTasksCard extends HTMLElement {
       alert("Bildgenerierung fehlgeschlagen: " + (err.message || err));
     } finally {
       this._generatingImage.delete(task.id);
+      this._render();
+    }
+  }
+
+  async _uploadTaskImage(task, colIdx, file) {
+    const col = this._config.columns[colIdx];
+
+    this._uploadingImage.add(task.id);
+    this._render();
+
+    try {
+      const formData = new FormData();
+      formData.append("entry_id", col.list_id);
+      formData.append("task_id", task.id);
+      formData.append("image", file);
+
+      // Use hass.fetchWithAuth if available (HA ≥ 2022), else add header manually
+      let resp;
+      if (typeof this._hass.fetchWithAuth === "function") {
+        resp = await this._hass.fetchWithAuth("/api/home_tasks/upload_image", { method: "POST", body: formData });
+      } else {
+        resp = await fetch("/api/home_tasks/upload_image", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${this._hass.auth.data.access_token}` },
+          body: formData,
+        });
+      }
+
+      if (!resp.ok) {
+        const body = await resp.text();
+        throw new Error(body || resp.statusText);
+      }
+      const result = await resp.json();
+
+      // Update local state immediately
+      const cs = this._columns[colIdx];
+      if (cs && cs.tasks && result.task) {
+        const idx = cs.tasks.findIndex(t => t.id === task.id);
+        if (idx >= 0) cs.tasks[idx] = result.task;
+      }
+    } catch (err) {
+      console.error("Image upload failed:", err);
+      alert("Bild hochladen fehlgeschlagen: " + (err.message || err));
+    } finally {
+      this._uploadingImage.delete(task.id);
       this._render();
     }
   }
@@ -6926,6 +7017,7 @@ class HomeTasksCardEditor extends HTMLElement {
           makeToggle("show-sort", "ed_show_sort", "show_sort", true),
           makeToggle("compact", "ed_compact", "compact", false),
           makeToggle("show-history", "ed_show_history", "show_history", false),
+          makeToggle("show-images", "ed_show_images", "show_images", false),
           makeToggle("show-tile-title", "ed_show_tile_title", "show_tile_title", true),
         ]),
         sortField,

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -1205,6 +1205,7 @@ class HomeTasksCard extends HTMLElement {
     this._weekPatternOverride = new Map();   // task.id → "on"
     this._yearPatternOverride = new Map();   // task.id → "on"
     this._generatingImage = new Set();       // task IDs currently generating
+    this._mediaSelectorOpen = new Set();     // task IDs with media selector visible
   }
 
   _defaultColState() {
@@ -1273,10 +1274,13 @@ class HomeTasksCard extends HTMLElement {
       const taskStillExists = this._columns.some(cs => cs.tasks?.some(t => t.id === this._editingTaskId));
       if (!taskStillExists) this._editingTaskId = null;
     }
-    // _expandedTasks is a Set of task IDs — clean up IDs no longer in any column
+    // _expandedTasks / _mediaSelectorOpen: clean up IDs no longer in any column
     const allTaskIds = new Set(this._columns.flatMap(cs => (cs.tasks || []).map(t => t.id)));
     for (const id of this._expandedTasks) {
       if (!allTaskIds.has(id)) this._expandedTasks.delete(id);
+    }
+    for (const id of this._mediaSelectorOpen) {
+      if (!allTaskIds.has(id)) this._mediaSelectorOpen.delete(id);
     }
 
     // Reset per-column filter/sort when list or defaults change
@@ -4916,7 +4920,6 @@ class HomeTasksCard extends HTMLElement {
 
   _buildImageSection(task, colIdx) {
     const col = this._config.columns[colIdx];
-    const imgCfg = this._config.image_generation || {};
     const isGenerating = this._generatingImage.has(task.id);
 
     const children = [];
@@ -4970,41 +4973,47 @@ class HomeTasksCard extends HTMLElement {
     genBtn.addEventListener("click", () => this._generateTaskImage(task, colIdx, !!task.image_url));
     children.push(genBtn);
 
-    // "Select from media" button — toggles ha-selector inline
+    // "Aus Mediathek" button — opens HA's native media browser dialog
     const selectBtn = this._el("button", {
       className: "generate-image-btn",
       disabled: busy,
     });
     selectBtn.innerHTML = `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right:6px;vertical-align:-3px"><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"/></svg>Aus Mediathek`;
+    selectBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this._openMediaPicker(task, colIdx);
+    });
     children.push(selectBtn);
-
-    // ha-selector (HA's built-in image/media picker) — shown on demand
-    const selectorWrap = document.createElement("div");
-    selectorWrap.className = "media-selector-wrap";
-    selectorWrap.style.display = "none";
-
-    const haSelector = document.createElement("ha-selector");
-    haSelector.hass = this._hass;
-    haSelector.selector = { image: {} };
-    haSelector.value = task.image_url || "";
-    haSelector.addEventListener("value-changed", (e) => {
-      const url = e.detail.value;
-      if (url !== undefined && url !== task.image_url) {
-        this._saveImageUrl(task, colIdx, url || null);
-        selectorWrap.style.display = "none";
-      }
-    });
-    selectorWrap.appendChild(haSelector);
-
-    selectBtn.addEventListener("click", () => {
-      selectorWrap.style.display = selectorWrap.style.display === "none" ? "block" : "none";
-    });
 
     return this._el("div", { className: "detail-section detail-section--image" }, [
       this._el("label", { className: "detail-label", textContent: "Bild" }),
       this._el("div", { className: "image-section-body" }, children),
-      selectorWrap,
     ]);
+  }
+
+  _openMediaPicker(task, colIdx) {
+    // Open HA's native media browser dialog via the show-dialog event.
+    // composed:true lets the event cross shadow DOM boundaries up to
+    // the top-level <home-assistant> element which handles show-dialog.
+    this.dispatchEvent(new CustomEvent("show-dialog", {
+      bubbles: true,
+      composed: true,
+      detail: {
+        dialogTag: "ha-media-player-browse-dialog",
+        dialogImport: () =>
+          customElements.get("ha-media-player-browse-dialog")
+            ? Promise.resolve()
+            : import("/frontend_latest/chunk.js").catch(() => Promise.resolve()),
+        dialogParams: {
+          action: "pick",
+          navigateIds: [{ params: {}, id: "media-source://media_source" }],
+          mediaPickedCallback: (item) => {
+            const url = item?.media_content_id;
+            if (url) this._saveImageUrl(task, colIdx, url);
+          },
+        },
+      },
+    }));
   }
 
   async _generateTaskImage(task, colIdx, force = false) {
@@ -5020,11 +5029,8 @@ class HomeTasksCard extends HTMLElement {
       task_id: task.id,
       force: force,
     };
-    if (imgCfg.api_key) payload.api_key = imgCfg.api_key;
-    if (imgCfg.endpoint) payload.endpoint = imgCfg.endpoint;
-    if (imgCfg.model) payload.model = imgCfg.model;
-    if (imgCfg.size) payload.size = imgCfg.size;
-    if (imgCfg.quality) payload.quality = imgCfg.quality;
+    // prompt_prefix is the only card-level config; model/key/quality are
+    // handled by the ai_task integration on the server side.
     if (imgCfg.prompt_prefix) payload.prompt_prefix = imgCfg.prompt_prefix;
 
     try {
@@ -6030,7 +6036,6 @@ class HomeTasksCard extends HTMLElement {
       .task-thumb:hover { opacity: 1; transform: scale(1.05); }
       .task.completed .task-thumb { opacity: 0.45; }
       .detail-section--image .image-section-body { display: flex; flex-direction: column; gap: 10px; }
-      .media-selector-wrap { margin-top: 6px; }
       .image-section-body { gap: 6px; }
       .image-section-body .generate-image-btn { flex: 1; }
       .task-image-wrap {

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -6414,7 +6414,6 @@ class HomeTasksCard extends HTMLElement {
       dialog.mb-dialog {
         padding: 0; border: none; border-radius: 12px;
         width: min(480px, 95vw); max-height: 70vh;
-        display: flex; flex-direction: column;
         background: var(--ha-card-background, var(--card-background-color, #fff));
         color: var(--primary-text-color);
         box-shadow: 0 8px 32px rgba(0,0,0,0.32);
@@ -6433,7 +6432,7 @@ class HomeTasksCard extends HTMLElement {
         display: flex; align-items: center;
       }
       .mb-close:hover { background: var(--secondary-background-color); }
-      .mb-list { overflow-y: auto; flex: 1; }
+      .mb-list { overflow-y: auto; max-height: calc(70vh - 64px); }
       .mb-status { padding: 32px; text-align: center; color: var(--secondary-text-color); font-size: 14px; }
       .mb-error { color: var(--error-color, #db4437); }
       .mb-crumb {

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -143,6 +143,8 @@ const _TRANSLATIONS = {
     ed_ms_add: "Add…",
     ed_ai_image_entity: "AI entity for image generation",
     ed_ai_image_entity_placeholder: "e.g. ai_task.openai",
+    ed_ai_prompt_prefix: "Prompt prefix (optional)",
+    ed_ai_prompt_prefix_placeholder: "e.g. Minimalist icon of",
   },
   nl: {
     my_tasks: "Mijn taken",
@@ -1149,6 +1151,8 @@ const _TRANSLATIONS = {
     ed_ms_add: "Hinzufügen…",
     ed_ai_image_entity: "KI-Entität für Bildgenerierung",
     ed_ai_image_entity_placeholder: "z.B. ai_task.openai",
+    ed_ai_prompt_prefix: "Prompt-Präfix (optional)",
+    ed_ai_prompt_prefix_placeholder: "z.B. Minimalistisches Icon von",
   },
 };
 
@@ -6504,6 +6508,8 @@ class HomeTasksCardEditor extends HTMLElement {
       :host { display: block; }
       .editor { display: flex; flex-direction: column; gap: 0; padding: 16px 0; }
       .editor-card-title-row { margin-bottom: 12px; }
+      .editor-imggen-row { display: flex; gap: 8px; }
+      .editor-imggen-row > * { flex: 1; min-width: 0; }
       .editor-tabs-row {
         display: flex; align-items: center;
         border-bottom: 1px solid var(--divider-color, #e0e0e0);
@@ -6615,17 +6621,47 @@ class HomeTasksCardEditor extends HTMLElement {
     });
     const cardTitleRow = this._el("div", { className: "editor-card-title-row" }, [cardTitleInput]);
 
-    const aiEntityInput = document.createElement("ha-textfield");
-    aiEntityInput.label = this._t("ed_ai_image_entity");
-    aiEntityInput.placeholder = this._t("ed_ai_image_entity_placeholder");
-    aiEntityInput.value = (this._config.image_generation || {}).entity_id || "";
-    aiEntityInput.style.width = "100%";
-    aiEntityInput.addEventListener("change", (e) => {
-      const val = e.target.value.trim() || undefined;
-      this._config = { ...this._config, image_generation: { ...(this._config.image_generation || {}), entity_id: val } };
+    const imgGen = this._config.image_generation || {};
+    const updateImgGen = (patch) => {
+      const merged = { ...imgGen, ...patch };
+      Object.keys(merged).forEach(k => merged[k] === undefined && delete merged[k]);
+      this._config = { ...this._config, image_generation: Object.keys(merged).length ? merged : undefined };
       this._fireChanged();
+    };
+
+    // Entity dropdown — populated from hass.states (domain: ai_task)
+    const aiEntities = Object.keys(this._hass?.states || {}).filter(e => e.startsWith("ai_task.")).sort();
+    const aiEntitySelect = document.createElement("ha-select");
+    aiEntitySelect.label = this._t("ed_ai_image_entity");
+    aiEntitySelect.style.width = "100%";
+    aiEntitySelect.fixedMenuPosition = true;
+    const autoOpt = document.createElement("mwc-list-item");
+    autoOpt.value = "";
+    autoOpt.textContent = "— Auto-detect —";
+    aiEntitySelect.appendChild(autoOpt);
+    for (const eid of aiEntities) {
+      const opt = document.createElement("mwc-list-item");
+      opt.value = eid;
+      opt.textContent = eid;
+      aiEntitySelect.appendChild(opt);
+    }
+    aiEntitySelect.value = imgGen.entity_id || "";
+    aiEntitySelect.addEventListener("selected", (e) => {
+      const val = e.target.value || undefined;
+      updateImgGen({ entity_id: val });
     });
-    const aiEntityRow = this._el("div", { className: "editor-card-title-row" }, [aiEntityInput]);
+
+    // Prompt prefix text field
+    const promptInput = document.createElement("ha-textfield");
+    promptInput.label = this._t("ed_ai_prompt_prefix");
+    promptInput.placeholder = this._t("ed_ai_prompt_prefix_placeholder");
+    promptInput.value = imgGen.prompt_prefix || "";
+    promptInput.style.width = "100%";
+    promptInput.addEventListener("change", (e) => {
+      updateImgGen({ prompt_prefix: e.target.value.trim() || undefined });
+    });
+
+    const aiEntityRow = this._el("div", { className: "editor-card-title-row editor-imggen-row" }, [aiEntitySelect, promptInput]);
 
     // Tab bar (tabs on left, + on right)
     const tabsEl = this._el("div", { className: "editor-tabs" });

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -1176,7 +1176,6 @@ class HomeTasksCard extends HTMLElement {
     // Per-column state: [{filter, sortBy, sortOpen, tagFilters, personFilters, tasks, newTaskTitle}]
     this._columns = [];
     this._expandedTasks = new Set();
-    this._uploadingImage = new Set();
     this._editingTaskId = null;
     this._editingSubTaskId = null;
     this._draggedTaskId = null;
@@ -4956,8 +4955,7 @@ class HomeTasksCard extends HTMLElement {
     }
 
     // --- Action buttons row ---
-    const isUploading = this._uploadingImage && this._uploadingImage.has(task.id);
-    const busy = isGenerating || isUploading;
+    const busy = isGenerating;
 
     // Generate button
     const genBtn = this._el("button", {
@@ -4972,32 +4970,40 @@ class HomeTasksCard extends HTMLElement {
     genBtn.addEventListener("click", () => this._generateTaskImage(task, colIdx, !!task.image_url));
     children.push(genBtn);
 
-    // Upload button + hidden file input
-    const uploadBtn = this._el("button", {
-      className: "generate-image-btn" + (busy ? " generating" : ""),
+    // "Select from media" button — toggles ha-selector inline
+    const selectBtn = this._el("button", {
+      className: "generate-image-btn",
       disabled: busy,
     });
-    if (isUploading) {
-      uploadBtn.innerHTML = `<span class="spinner"></span> Lade hoch…`;
-    } else {
-      uploadBtn.innerHTML = `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right:6px;vertical-align:-3px"><path d="M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z"/></svg>Hochladen`;
-    }
-    const fileInput = document.createElement("input");
-    fileInput.type = "file";
-    fileInput.accept = "image/*";
-    fileInput.style.display = "none";
-    fileInput.addEventListener("change", () => {
-      const file = fileInput.files[0];
-      if (file) this._uploadTaskImage(task, colIdx, file);
-      fileInput.value = "";
+    selectBtn.innerHTML = `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right:6px;vertical-align:-3px"><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"/></svg>Aus Mediathek`;
+    children.push(selectBtn);
+
+    // ha-selector (HA's built-in image/media picker) — shown on demand
+    const selectorWrap = document.createElement("div");
+    selectorWrap.className = "media-selector-wrap";
+    selectorWrap.style.display = "none";
+
+    const haSelector = document.createElement("ha-selector");
+    haSelector.hass = this._hass;
+    haSelector.selector = { image: {} };
+    haSelector.value = task.image_url || "";
+    haSelector.addEventListener("value-changed", (e) => {
+      const url = e.detail.value;
+      if (url !== undefined && url !== task.image_url) {
+        this._saveImageUrl(task, colIdx, url || null);
+        selectorWrap.style.display = "none";
+      }
     });
-    uploadBtn.addEventListener("click", () => fileInput.click());
-    children.push(uploadBtn);
+    selectorWrap.appendChild(haSelector);
+
+    selectBtn.addEventListener("click", () => {
+      selectorWrap.style.display = selectorWrap.style.display === "none" ? "block" : "none";
+    });
 
     return this._el("div", { className: "detail-section detail-section--image" }, [
       this._el("label", { className: "detail-label", textContent: "Bild" }),
       this._el("div", { className: "image-section-body" }, children),
-      fileInput,
+      selectorWrap,
     ]);
   }
 
@@ -5038,48 +5044,24 @@ class HomeTasksCard extends HTMLElement {
     }
   }
 
-  async _uploadTaskImage(task, colIdx, file) {
+  async _saveImageUrl(task, colIdx, url) {
     const col = this._config.columns[colIdx];
-
-    this._uploadingImage.add(task.id);
-    this._render();
-
     try {
-      const formData = new FormData();
-      formData.append("entry_id", col.list_id);
-      formData.append("task_id", task.id);
-      formData.append("image", file);
-
-      // Use hass.fetchWithAuth if available (HA ≥ 2022), else add header manually
-      let resp;
-      if (typeof this._hass.fetchWithAuth === "function") {
-        resp = await this._hass.fetchWithAuth("/api/home_tasks/upload_image", { method: "POST", body: formData });
-      } else {
-        resp = await fetch("/api/home_tasks/upload_image", {
-          method: "POST",
-          headers: { Authorization: `Bearer ${this._hass.auth.data.access_token}` },
-          body: formData,
-        });
-      }
-
-      if (!resp.ok) {
-        const body = await resp.text();
-        throw new Error(body || resp.statusText);
-      }
-      const result = await resp.json();
-
-      // Update local state immediately
+      const result = await this._hass.callWS({
+        type: "home_tasks/update_task",
+        list_id: col.list_id,
+        task_id: task.id,
+        image_url: url,
+      });
       const cs = this._columns[colIdx];
-      if (cs && cs.tasks && result.task) {
+      if (cs && cs.tasks) {
         const idx = cs.tasks.findIndex(t => t.id === task.id);
-        if (idx >= 0) cs.tasks[idx] = result.task;
+        if (idx >= 0) cs.tasks[idx] = result;
       }
-    } catch (err) {
-      console.error("Image upload failed:", err);
-      alert("Bild hochladen fehlgeschlagen: " + (err.message || err));
-    } finally {
-      this._uploadingImage.delete(task.id);
       this._render();
+    } catch (err) {
+      console.error("Failed to save image URL:", err);
+      alert("Bild speichern fehlgeschlagen: " + (err.message || err));
     }
   }
 
@@ -6048,6 +6030,9 @@ class HomeTasksCard extends HTMLElement {
       .task-thumb:hover { opacity: 1; transform: scale(1.05); }
       .task.completed .task-thumb { opacity: 0.45; }
       .detail-section--image .image-section-body { display: flex; flex-direction: column; gap: 10px; }
+      .media-selector-wrap { margin-top: 6px; }
+      .image-section-body { gap: 6px; }
+      .image-section-body .generate-image-btn { flex: 1; }
       .task-image-wrap {
         position: relative; display: inline-block; width: 100%;
         border-radius: 8px; overflow: hidden;

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -11,6 +11,7 @@ const _TRANSLATIONS = {
   en: {
     my_tasks: "My Tasks",
     add_placeholder: "Add new task...",
+    dialog_cancel: "Cancel", dialog_add: "Add",
     filter_all: "All",
     filter_open: "Open",
     filter_done: "Done",
@@ -143,6 +144,7 @@ const _TRANSLATIONS = {
   nl: {
     my_tasks: "Mijn taken",
     add_placeholder: "Nieuwe taak toevoegen...",
+    dialog_cancel: "Annuleren", dialog_add: "Toevoegen",
     filter_all: "Alle", filter_open: "Open", filter_done: "Klaar", filter_due_soon: "Binnenkort",
     ed_show_due_soon_filter: "Binnenkort-filter", ed_due_soon_days: "Dagen vooruit", ed_hide_overdue: "Verlopen verbergen",
     progress: "{0} van {1} klaar",
@@ -209,6 +211,7 @@ const _TRANSLATIONS = {
   it: {
     my_tasks: "Le mie attivit\u00e0",
     add_placeholder: "Aggiungi nuova attivit\u00e0...",
+    dialog_cancel: "Annulla", dialog_add: "Aggiungi",
     filter_all: "Tutte", filter_open: "Aperte", filter_done: "Completate", filter_due_soon: "In scadenza",
     ed_show_due_soon_filter: "Filtro in scadenza", ed_due_soon_days: "Giorni avanti", ed_hide_overdue: "Nascondi scadute",
     progress: "{0} di {1} completate",
@@ -275,6 +278,7 @@ const _TRANSLATIONS = {
   pl: {
     my_tasks: "Moje zadania",
     add_placeholder: "Dodaj nowe zadanie...",
+    dialog_cancel: "Anuluj", dialog_add: "Dodaj",
     filter_all: "Wszystkie", filter_open: "Otwarte", filter_done: "Uko\u0144czone", filter_due_soon: "Wkr\u00f3tce",
     ed_show_due_soon_filter: "Filtr wkr\u00f3tce", ed_due_soon_days: "Dni naprz\u00f3d", ed_hide_overdue: "Ukryj zaleg\u0142e",
     progress: "{0} z {1} uko\u0144czono",
@@ -341,6 +345,7 @@ const _TRANSLATIONS = {
   sv: {
     my_tasks: "Mina uppgifter",
     add_placeholder: "L\u00e4gg till ny uppgift...",
+    dialog_cancel: "Avbryt", dialog_add: "L\u00e4gg till",
     filter_all: "Alla", filter_open: "\u00d6ppna", filter_done: "Klara", filter_due_soon: "Snart",
     ed_show_due_soon_filter: "Snart-filter", ed_due_soon_days: "Dagar fram\u00e5t", ed_hide_overdue: "D\u00f6lj f\u00f6rsenade",
     progress: "{0} av {1} klara",
@@ -407,6 +412,7 @@ const _TRANSLATIONS = {
   fr: {
     my_tasks: "Mes t\u00e2ches",
     add_placeholder: "Ajouter une nouvelle t\u00e2che...",
+    dialog_cancel: "Annuler", dialog_add: "Ajouter",
     filter_all: "Toutes", filter_open: "Ouvertes", filter_done: "Termin\u00e9es", filter_due_soon: "Bient\u00f4t",
     ed_show_due_soon_filter: "Filtre bient\u00f4t", ed_due_soon_days: "Jours \u00e0 venir", ed_hide_overdue: "Masquer en retard",
     progress: "{0} sur {1} termin\u00e9es",
@@ -473,6 +479,7 @@ const _TRANSLATIONS = {
   pt: {
     my_tasks: "Minhas tarefas",
     add_placeholder: "Adicionar nova tarefa...",
+    dialog_cancel: "Cancelar", dialog_add: "Adicionar",
     filter_all: "Todas", filter_open: "Abertas", filter_done: "Conclu\u00eddas", filter_due_soon: "Em breve",
     ed_show_due_soon_filter: "Filtro em breve", ed_due_soon_days: "Dias \u00e0 frente", ed_hide_overdue: "Ocultar atrasadas",
     progress: "{0} de {1} conclu\u00eddas",
@@ -539,6 +546,7 @@ const _TRANSLATIONS = {
   es: {
     my_tasks: "Mis tareas",
     add_placeholder: "A\u00f1adir nueva tarea...",
+    dialog_cancel: "Cancelar", dialog_add: "Agregar",
     filter_all: "Todas", filter_open: "Abiertas", filter_done: "Completadas", filter_due_soon: "Pr\u00f3ximamente",
     ed_show_due_soon_filter: "Filtro pr\u00f3ximo", ed_due_soon_days: "D\u00edas adelante", ed_hide_overdue: "Ocultar vencidas",
     progress: "{0} de {1} completadas",
@@ -605,6 +613,7 @@ const _TRANSLATIONS = {
   ru: {
     my_tasks: "\u041c\u043e\u0438 \u0437\u0430\u0434\u0430\u0447\u0438",
     add_placeholder: "\u0414\u043e\u0431\u0430\u0432\u0438\u0442\u044c \u043d\u043e\u0432\u0443\u044e \u0437\u0430\u0434\u0430\u0447\u0443...",
+    dialog_cancel: "\u041e\u0442\u043c\u0435\u043d\u0430", dialog_add: "\u0414\u043e\u0431\u0430\u0432\u0438\u0442\u044c",
     filter_all: "\u0412\u0441\u0435", filter_open: "\u041e\u0442\u043a\u0440\u044b\u0442\u044b\u0435", filter_done: "\u0412\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u043d\u044b\u0435", filter_due_soon: "\u0421\u043a\u043e\u0440\u043e",
     ed_show_due_soon_filter: "\u0424\u0438\u043b\u044c\u0442\u0440 \u0441\u043a\u043e\u0440\u043e", ed_due_soon_days: "\u0414\u043d\u0435\u0439 \u0432\u043f\u0435\u0440\u0451\u0434", ed_hide_overdue: "\u0421\u043a\u0440\u044b\u0442\u044c \u043f\u0440\u043e\u0441\u0440\u043e\u0447\u0435\u043d\u043d\u044b\u0435",
     progress: "{0} \u0438\u0437 {1} \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u043e",
@@ -671,6 +680,7 @@ const _TRANSLATIONS = {
   cs: {
     my_tasks: "Moje \u00fakoly",
     add_placeholder: "P\u0159idat nov\u00fd \u00fakol...",
+    dialog_cancel: "Zru\u0161it", dialog_add: "P\u0159idat",
     filter_all: "V\u0161e", filter_open: "Otev\u0159en\u00e9", filter_done: "Dokon\u010den\u00e9", filter_due_soon: "Brzy",
     ed_show_due_soon_filter: "Filtr brzy", ed_due_soon_days: "Dn\u016f dop\u0159edu", ed_hide_overdue: "Skr\u00fdt po term\u00ednu",
     progress: "{0} z {1} dokon\u010deno",
@@ -737,6 +747,7 @@ const _TRANSLATIONS = {
   da: {
     my_tasks: "Mine opgaver",
     add_placeholder: "Tilf\u00f8j ny opgave...",
+    dialog_cancel: "Annull\u00e9r", dialog_add: "Tilf\u00f8j",
     filter_all: "Alle", filter_open: "\u00c5bne", filter_done: "F\u00e6rdige", filter_due_soon: "Snart",
     ed_show_due_soon_filter: "Snart-filter", ed_due_soon_days: "Dage frem", ed_hide_overdue: "Skjul forfaldne",
     progress: "{0} af {1} f\u00e6rdige",
@@ -803,6 +814,7 @@ const _TRANSLATIONS = {
   no: {
     my_tasks: "Mine oppgaver",
     add_placeholder: "Legg til ny oppgave...",
+    dialog_cancel: "Avbryt", dialog_add: "Legg til",
     filter_all: "Alle", filter_open: "\u00c5pne", filter_done: "Ferdige", filter_due_soon: "Snart",
     ed_show_due_soon_filter: "Snart-filter", ed_due_soon_days: "Dager fremover", ed_hide_overdue: "Skjul forfalte",
     progress: "{0} av {1} ferdige",
@@ -869,6 +881,7 @@ const _TRANSLATIONS = {
   fi: {
     my_tasks: "Omat teht\u00e4v\u00e4t",
     add_placeholder: "Lis\u00e4\u00e4 uusi teht\u00e4v\u00e4...",
+    dialog_cancel: "Peruuta", dialog_add: "Lis\u00e4\u00e4",
     filter_all: "Kaikki", filter_open: "Avoimet", filter_done: "Valmiit", filter_due_soon: "Pian",
     ed_show_due_soon_filter: "Pian-suodatin", ed_due_soon_days: "P\u00e4ivi\u00e4 eteenp\u00e4in", ed_hide_overdue: "Piilota my\u00f6h\u00e4ss\u00e4 olevat",
     progress: "{0} / {1} valmis",
@@ -935,6 +948,7 @@ const _TRANSLATIONS = {
   hu: {
     my_tasks: "Feladataim",
     add_placeholder: "\u00daj feladat hozz\u00e1ad\u00e1sa...",
+    dialog_cancel: "M\u00e9gse", dialog_add: "Hozz\u00e1ad",
     filter_all: "\u00d6sszes", filter_open: "Nyitott", filter_done: "K\u00e9sz", filter_due_soon: "Hamarosan",
     ed_show_due_soon_filter: "Hamarosan sz\u0171r\u0151", ed_due_soon_days: "Napok el\u0151re", ed_hide_overdue: "Lej\u00e1rtak elrejt\u00e9se",
     progress: "{0} / {1} k\u00e9sz",
@@ -1001,6 +1015,7 @@ const _TRANSLATIONS = {
   de: {
     my_tasks: "Meine Aufgaben",
     add_placeholder: "Neue Aufgabe hinzuf\u00fcgen...",
+    dialog_cancel: "Abbrechen", dialog_add: "Hinzuf\u00fcgen",
     filter_all: "Alle",
     filter_open: "Offen",
     filter_done: "Erledigt",
@@ -2792,11 +2807,7 @@ class HomeTasksCard extends HTMLElement {
 
   _buildColumnTileGrid(filteredTasks, colIdx) {
     const col = this._config.columns[colIdx];
-
-    if (filteredTasks.length === 0) {
-      const empty = this._el("div", { className: "empty-state", textContent: this._t("empty") });
-      return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [empty]);
-    }
+    const showAdd = col.show_add_task !== false && !this._isExternalCol(colIdx);
 
     // Open tasks first, completed after
     const openTasks = filteredTasks.filter(t => !t.completed);
@@ -2804,8 +2815,61 @@ class HomeTasksCard extends HTMLElement {
     const ordered = [...openTasks, ...doneTasks];
 
     const tileEls = ordered.map(task => this._buildTaskTile(task, colIdx));
+    if (showAdd) tileEls.push(this._buildAddTaskTile(colIdx));
+
+    if (tileEls.length === 0) {
+      const empty = this._el("div", { className: "empty-state", textContent: this._t("empty") });
+      return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [empty]);
+    }
+
     const grid = this._el("div", { className: "tile-grid-inner" }, tileEls);
     return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [grid]);
+  }
+
+  _buildAddTaskTile(colIdx) {
+    const tile = this._el("div", { className: "task-tile add-tile", title: this._t("add_placeholder") });
+    tile.appendChild(this._el("div", { className: "add-tile-icon", textContent: "+" }));
+    tile.addEventListener("click", () => this._showTileAddDialog(colIdx));
+    return tile;
+  }
+
+  _showTileAddDialog(colIdx) {
+    const cs = this._columns[colIdx];
+
+    const doAdd = async () => {
+      const title = (tf.value || "").trim();
+      if (!title) return;
+      dlg.open = false;
+      cs.newTaskTitle = title;
+      await this._addTask(colIdx);
+    };
+
+    const tf = document.createElement("ha-textfield");
+    tf.setAttribute("label", this._t("add_placeholder"));
+    tf.setAttribute("dialogInitialFocus", "");
+    tf.style.width = "100%";
+    tf.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") doAdd();
+      if (e.key === "Escape") { dlg.open = false; }
+    });
+
+    const cancelBtn = document.createElement("mwc-button");
+    cancelBtn.slot = "secondaryAction";
+    cancelBtn.setAttribute("dialogAction", "close");
+    cancelBtn.textContent = this._t("dialog_cancel");
+
+    const confirmBtn = document.createElement("mwc-button");
+    confirmBtn.slot = "primaryAction";
+    confirmBtn.setAttribute("raised", "");
+    confirmBtn.textContent = this._t("dialog_add");
+    confirmBtn.addEventListener("click", doAdd);
+
+    const dlg = document.createElement("ha-dialog");
+    dlg.heading = this._t("add_placeholder");
+    dlg.open = true;
+    dlg.append(tf, cancelBtn, confirmBtn);
+    dlg.addEventListener("closed", () => dlg.remove(), { once: true });
+    document.body.appendChild(dlg);
   }
 
   _buildTaskTile(task, colIdx) {
@@ -5857,10 +5921,26 @@ class HomeTasksCard extends HTMLElement {
       }
       .tiles-mode { padding: 12px; }
 
+      /* Add-task tile */
+      .add-tile {
+        border: 2px dashed var(--todo-divider);
+        background: transparent;
+        display: flex; align-items: center; justify-content: center;
+        color: var(--secondary-text-color);
+        transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+      }
+      .add-tile:hover {
+        border-color: var(--primary-color);
+        color: var(--primary-color);
+        background: color-mix(in srgb, var(--primary-color) 8%, transparent);
+      }
+      .add-tile-icon { font-size: 2.2rem; font-weight: 300; line-height: 1; pointer-events: none; }
+
       /* Compact tile variant */
       .compact .tile-grid-inner { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 7px; }
       .compact .task-tile { border-radius: 10px; }
       .compact .tile-title { font-size: 11px; }
+      .compact .add-tile-icon { font-size: 1.8rem; }
 
       @keyframes task-exit {
         0%   { opacity: 1; transform: translateY(0); }

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -3204,7 +3204,7 @@ class HomeTasksCard extends HTMLElement {
     const taskEl = this._el("div", { className, draggable: !isEditing && !isExpanded });
     taskEl.dataset.taskId = task.id;
 
-    // --- main row: checkbox + content + expand button ---
+    // --- main row: checkbox + content + [thumb] + expand button ---
     const checkboxEl = this._buildTaskCheckbox(task, colIdx);
     const contentChildren = this._buildTaskContentChildren(task, colIdx, isEditing);
     const metaBadges = this._buildTaskMetaBadges(task, col, cs, colIdx);
@@ -3214,7 +3214,26 @@ class HomeTasksCard extends HTMLElement {
     const contentEl = this._el("div", { className: "task-content" }, contentChildren);
     const expandBtn = this._buildTaskExpandButton(isExpanded);
 
-    const mainRow = this._el("div", { className: "task-main" }, [checkboxEl, contentEl, expandBtn]);
+    const mainRowChildren = [checkboxEl, contentEl];
+    if (task.image_url && !isEditing) {
+      const thumb = this._el("img", {
+        className: "task-thumb",
+        src: task.image_url,
+        alt: "",
+        title: task.title,
+      });
+      // Click on thumbnail expands the task to show full image
+      thumb.addEventListener("click", (e) => {
+        e.stopPropagation();
+        if (isExpanded) this._expandedTasks.delete(task.id);
+        else this._expandedTasks.add(task.id);
+        this._render();
+      });
+      mainRowChildren.push(thumb);
+    }
+    mainRowChildren.push(expandBtn);
+
+    const mainRow = this._el("div", { className: "task-main" }, mainRowChildren);
     this._attachTaskExpandClickHandler(mainRow, task, taskEl);
     taskEl.appendChild(mainRow);
 
@@ -3271,15 +3290,6 @@ class HomeTasksCard extends HTMLElement {
         this._render();
       });
       children.push(titleSpan);
-      // Thumbnail in task row if image exists
-      if (task.image_url) {
-        children.push(this._el("img", {
-          className: "task-thumb",
-          src: task.image_url,
-          alt: "",
-          title: task.title,
-        }));
-      }
     }
     return children;
   }
@@ -5940,11 +5950,12 @@ class HomeTasksCard extends HTMLElement {
 
       /* --- Task image --- */
       .task-thumb {
-        width: 36px; height: 36px; border-radius: 4px; object-fit: cover;
-        flex-shrink: 0; margin-left: 6px; opacity: 0.85; transition: opacity 0.2s;
-        cursor: pointer;
+        width: 40px; height: 40px; border-radius: 6px; object-fit: cover;
+        flex-shrink: 0; opacity: 0.88; transition: opacity 0.2s, transform 0.15s;
+        cursor: pointer; border: 1px solid var(--todo-divider);
       }
-      .task-thumb:hover { opacity: 1; }
+      .task-thumb:hover { opacity: 1; transform: scale(1.05); }
+      .task.completed .task-thumb { opacity: 0.45; }
       .detail-section--image .image-section-body { display: flex; flex-direction: column; gap: 10px; }
       .task-image-wrap {
         position: relative; display: inline-block; width: 100%;
@@ -6011,6 +6022,7 @@ class HomeTasksCard extends HTMLElement {
       .compact .task-main { padding: 6px 8px; gap: 6px; min-height: 32px; }
       .compact .task-title { font-size: 13px; }
       .compact .task-meta { gap: 4px; }
+      .compact .task-thumb { width: 30px; height: 30px; border-radius: 4px; }
       .compact .sub-badge, .compact .due-date, .compact .priority-badge, .compact .recurrence-badge,
       .compact .assigned-badge, .compact .tag-badge, .compact .reminder-badge { font-size: 10px; padding: 1px 6px; }
       .compact .checkmark { height: 16px; width: 16px; }

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -6508,8 +6508,17 @@ class HomeTasksCardEditor extends HTMLElement {
       :host { display: block; }
       .editor { display: flex; flex-direction: column; gap: 0; padding: 16px 0; }
       .editor-card-title-row { margin-bottom: 12px; }
-      .editor-imggen-row { display: flex; gap: 8px; }
-      .editor-imggen-row > * { flex: 1; min-width: 0; }
+      .editor-imggen-row { display: flex; gap: 12px; }
+      .editor-imggen-field { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+      .editor-field-label { font-size: 12px; color: var(--secondary-text-color); }
+      .editor-native-select, .editor-native-input {
+        width: 100%; box-sizing: border-box; padding: 8px;
+        background: var(--card-background-color); color: var(--primary-text-color);
+        border: 1px solid var(--divider-color); border-radius: 4px; font-size: 14px;
+      }
+      .editor-native-select:focus, .editor-native-input:focus {
+        outline: none; border-color: var(--primary-color);
+      }
       .editor-tabs-row {
         display: flex; align-items: center;
         border-bottom: 1px solid var(--divider-color, #e0e0e0);
@@ -6629,39 +6638,31 @@ class HomeTasksCardEditor extends HTMLElement {
       this._fireChanged();
     };
 
-    // Entity dropdown — populated from hass.states (domain: ai_task)
+    // Entity dropdown — native <select> + prompt prefix input
     const aiEntities = Object.keys(this._hass?.states || {}).filter(e => e.startsWith("ai_task.")).sort();
-    const aiEntitySelect = document.createElement("ha-select");
-    aiEntitySelect.label = this._t("ed_ai_image_entity");
-    aiEntitySelect.style.width = "100%";
-    aiEntitySelect.fixedMenuPosition = true;
-    const autoOpt = document.createElement("mwc-list-item");
-    autoOpt.value = "";
-    autoOpt.textContent = "— Auto-detect —";
-    aiEntitySelect.appendChild(autoOpt);
-    for (const eid of aiEntities) {
-      const opt = document.createElement("mwc-list-item");
-      opt.value = eid;
-      opt.textContent = eid;
-      aiEntitySelect.appendChild(opt);
-    }
+    const aiEntitySelect = this._el("select", { className: "editor-native-select" });
+    aiEntitySelect.appendChild(this._el("option", { value: "", textContent: "— Auto-detect —" }));
+    for (const eid of aiEntities) aiEntitySelect.appendChild(this._el("option", { value: eid, textContent: eid }));
     aiEntitySelect.value = imgGen.entity_id || "";
-    aiEntitySelect.addEventListener("selected", (e) => {
-      const val = e.target.value || undefined;
-      updateImgGen({ entity_id: val });
-    });
+    aiEntitySelect.addEventListener("change", (e) => updateImgGen({ entity_id: e.target.value || undefined }));
 
-    // Prompt prefix text field
-    const promptInput = document.createElement("ha-textfield");
-    promptInput.label = this._t("ed_ai_prompt_prefix");
-    promptInput.placeholder = this._t("ed_ai_prompt_prefix_placeholder");
-    promptInput.value = imgGen.prompt_prefix || "";
-    promptInput.style.width = "100%";
-    promptInput.addEventListener("change", (e) => {
-      updateImgGen({ prompt_prefix: e.target.value.trim() || undefined });
+    const promptInput = this._el("input", {
+      type: "text", className: "editor-native-input",
+      placeholder: this._t("ed_ai_prompt_prefix_placeholder"),
+      value: imgGen.prompt_prefix || "",
     });
+    promptInput.addEventListener("change", (e) => updateImgGen({ prompt_prefix: e.target.value.trim() || undefined }));
 
-    const aiEntityRow = this._el("div", { className: "editor-card-title-row editor-imggen-row" }, [aiEntitySelect, promptInput]);
+    const aiEntityRow = this._el("div", { className: "editor-card-title-row editor-imggen-row" }, [
+      this._el("div", { className: "editor-imggen-field" }, [
+        this._el("span", { className: "editor-field-label", textContent: this._t("ed_ai_image_entity") }),
+        aiEntitySelect,
+      ]),
+      this._el("div", { className: "editor-imggen-field" }, [
+        this._el("span", { className: "editor-field-label", textContent: this._t("ed_ai_prompt_prefix") }),
+        promptInput,
+      ]),
+    ]);
 
     // Tab bar (tabs on left, + on right)
     const tabsEl = this._el("div", { className: "editor-tabs" });

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -146,6 +146,7 @@ const _TRANSLATIONS = {
     ed_ai_image_entity_placeholder: "e.g. ai_task.openai",
     ed_ai_prompt_prefix: "Prompt prefix (optional)",
     ed_ai_prompt_prefix_placeholder: "e.g. Minimalist icon of",
+    assign_to_another: "Assign to another person",
   },
   nl: {
     my_tasks: "Mijn taken",
@@ -213,6 +214,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Overmorgen", due_day_before_yesterday: "Eergisteren",
     due_in_hours: "Over {0} u {1} min", due_in_minutes: "Over {0} min", due_in_seconds: "Nu",
     due_ago_hours: "{0} u {1} min geleden", due_ago_minutes: "{0} min geleden", due_ago_seconds: "Zojuist",
+    assign_to_another: "Ook toewijzen aan",
   },
   it: {
     my_tasks: "Le mie attivit\u00e0",
@@ -280,6 +282,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Dopodomani", due_day_before_yesterday: "L'altroieri",
     due_in_hours: "Tra {0} h {1} min", due_in_minutes: "Tra {0} min", due_in_seconds: "Adesso",
     due_ago_hours: "{0} h {1} min fa", due_ago_minutes: "{0} min fa", due_ago_seconds: "Proprio ora",
+    assign_to_another: "Assegna anche a",
   },
   pl: {
     my_tasks: "Moje zadania",
@@ -347,6 +350,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Pojutrze", due_day_before_yesterday: "Przedwczoraj",
     due_in_hours: "Za {0} godz. {1} min", due_in_minutes: "Za {0} min", due_in_seconds: "Teraz",
     due_ago_hours: "{0} godz. {1} min temu", due_ago_minutes: "{0} min temu", due_ago_seconds: "W\u0142a\u015bnie",
+    assign_to_another: "Przypisz r\u00f3wnie\u017c do",
   },
   sv: {
     my_tasks: "Mina uppgifter",
@@ -414,6 +418,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "\u00d6vermorgon", due_day_before_yesterday: "F\u00f6rrg\u00e5r",
     due_in_hours: "Om {0} tim {1} min", due_in_minutes: "Om {0} min", due_in_seconds: "Nu",
     due_ago_hours: "{0} tim {1} min sedan", due_ago_minutes: "{0} min sedan", due_ago_seconds: "Just nu",
+    assign_to_another: "Tilldela även till",
   },
   fr: {
     my_tasks: "Mes t\u00e2ches",
@@ -481,6 +486,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Apr\u00e8s-demain", due_day_before_yesterday: "Avant-hier",
     due_in_hours: "Dans {0} h {1} min", due_in_minutes: "Dans {0} min", due_in_seconds: "Maintenant",
     due_ago_hours: "Il y a {0} h {1} min", due_ago_minutes: "Il y a {0} min", due_ago_seconds: "\u00c0 l'instant",
+    assign_to_another: "Assigner \u00e9galement \u00e0",
   },
   pt: {
     my_tasks: "Minhas tarefas",
@@ -548,6 +554,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Depois de amanh\u00e3", due_day_before_yesterday: "Anteontem",
     due_in_hours: "Em {0} h {1} min", due_in_minutes: "Em {0} min", due_in_seconds: "Agora",
     due_ago_hours: "H\u00e1 {0} h {1} min", due_ago_minutes: "H\u00e1 {0} min", due_ago_seconds: "Agora mesmo",
+    assign_to_another: "Atribuir tamb\u00e9m a",
   },
   es: {
     my_tasks: "Mis tareas",
@@ -615,6 +622,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Pasado ma\u00f1ana", due_day_before_yesterday: "Anteayer",
     due_in_hours: "En {0} h {1} min", due_in_minutes: "En {0} min", due_in_seconds: "Ahora",
     due_ago_hours: "Hace {0} h {1} min", due_ago_minutes: "Hace {0} min", due_ago_seconds: "Ahora mismo",
+    assign_to_another: "Asignar también a",
   },
   ru: {
     my_tasks: "\u041c\u043e\u0438 \u0437\u0430\u0434\u0430\u0447\u0438",
@@ -682,6 +690,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "\u041f\u043e\u0441\u043b\u0435\u0437\u0430\u0432\u0442\u0440\u0430", due_day_before_yesterday: "\u041f\u043e\u0437\u0430\u0432\u0447\u0435\u0440\u0430",
     due_in_hours: "\u0427\u0435\u0440\u0435\u0437 {0} \u0447 {1} \u043c\u0438\u043d", due_in_minutes: "\u0427\u0435\u0440\u0435\u0437 {0} \u043c\u0438\u043d", due_in_seconds: "\u0421\u0435\u0439\u0447\u0430\u0441",
     due_ago_hours: "{0} \u0447 {1} \u043c\u0438\u043d \u043d\u0430\u0437\u0430\u0434", due_ago_minutes: "{0} \u043c\u0438\u043d \u043d\u0430\u0437\u0430\u0434", due_ago_seconds: "\u0422\u043e\u043b\u044c\u043a\u043e \u0447\u0442\u043e",
+    assign_to_another: "\u041d\u0430\u0437\u043d\u0430\u0447\u0438\u0442\u044c \u0442\u0430\u043a\u0436\u0435",
   },
   cs: {
     my_tasks: "Moje \u00fakoly",
@@ -749,6 +758,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Poz\u00edt\u0159\u00ed", due_day_before_yesterday: "P\u0159edev\u010d\u00edrem",
     due_in_hours: "Za {0} hod {1} min", due_in_minutes: "Za {0} min", due_in_seconds: "Nyn\u00ed",
     due_ago_hours: "P\u0159ed {0} hod {1} min", due_ago_minutes: "P\u0159ed {0} min", due_ago_seconds: "Pr\u00e1v\u011b te\u010f",
+    assign_to_another: "P\u0159i\u0159adit tak\u00e9",
   },
   da: {
     my_tasks: "Mine opgaver",
@@ -816,6 +826,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "I overmorgen", due_day_before_yesterday: "I forg\u00e5rs",
     due_in_hours: "Om {0} t {1} min", due_in_minutes: "Om {0} min", due_in_seconds: "Nu",
     due_ago_hours: "{0} t {1} min siden", due_ago_minutes: "{0} min siden", due_ago_seconds: "Lige nu",
+    assign_to_another: "Tildel også til",
   },
   no: {
     my_tasks: "Mine oppgaver",
@@ -883,6 +894,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "I overmorgen", due_day_before_yesterday: "I forg\u00e5rs",
     due_in_hours: "Om {0} t {1} min", due_in_minutes: "Om {0} min", due_in_seconds: "N\u00e5",
     due_ago_hours: "{0} t {1} min siden", due_ago_minutes: "{0} min siden", due_ago_seconds: "Akkurat n\u00e5",
+    assign_to_another: "Tildel ogs\u00e5 til",
   },
   fi: {
     my_tasks: "Omat teht\u00e4v\u00e4t",
@@ -950,6 +962,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Ylihuomenna", due_day_before_yesterday: "Toissap\u00e4iv\u00e4n\u00e4",
     due_in_hours: "{0} t {1} min p\u00e4\u00e4st\u00e4", due_in_minutes: "{0} min p\u00e4\u00e4st\u00e4", due_in_seconds: "Nyt",
     due_ago_hours: "{0} t {1} min sitten", due_ago_minutes: "{0} min sitten", due_ago_seconds: "Juuri nyt",
+    assign_to_another: "Määritä myös",
   },
   hu: {
     my_tasks: "Feladataim",
@@ -1017,6 +1030,7 @@ const _TRANSLATIONS = {
     due_day_after_tomorrow: "Holnaput\u00e1n", due_day_before_yesterday: "Tegnapel\u0151tt",
     due_in_hours: "{0} \u00f3 {1} perc m\u00falva", due_in_minutes: "{0} perc m\u00falva", due_in_seconds: "Most",
     due_ago_hours: "{0} \u00f3 {1} perccel ezel\u0151tt", due_ago_minutes: "{0} perccel ezel\u0151tt", due_ago_seconds: "\u00c9pp most",
+    assign_to_another: "Hozz\u00e1rendel\u00e9s m\u00e1snak is",
   },
   de: {
     my_tasks: "Meine Aufgaben",
@@ -1155,6 +1169,7 @@ const _TRANSLATIONS = {
     ed_ai_image_entity_placeholder: "z.B. ai_task.openai",
     ed_ai_prompt_prefix: "Prompt-Präfix (optional)",
     ed_ai_prompt_prefix_placeholder: "z.B. Minimalistisches Icon von",
+    assign_to_another: "Auch zuweisen an…",
   },
 };
 
@@ -4975,12 +4990,59 @@ class HomeTasksCard extends HTMLElement {
   }
 
   _buildActionsSection(task, colIdx) {
+    const children = [];
+
+    if (!this._isExternalCol(colIdx)) {
+      const assignBtn = this._el("button", {
+        className: "assign-copy-btn",
+        textContent: this._t("assign_to_another"),
+      });
+      assignBtn.addEventListener("click", () => {
+        const sel = document.createElement("select");
+        sel.className = "assign-copy-sel";
+        const cancelOpt = this._el("option", { value: "", textContent: "—" });
+        sel.appendChild(cancelOpt);
+        if (this._hass && this._hass.states) {
+          const persons = Object.keys(this._hass.states).filter(e => e.startsWith("person.")).sort();
+          for (const eid of persons) {
+            const state = this._hass.states[eid];
+            const name = (state && state.attributes && state.attributes.friendly_name) || eid;
+            sel.appendChild(this._el("option", { value: eid, textContent: name }));
+          }
+        }
+        sel.addEventListener("change", () => {
+          if (sel.value) this._duplicateAndAssign(task, colIdx, sel.value);
+          sel.replaceWith(assignBtn);
+        });
+        sel.addEventListener("blur", () => { if (sel.parentNode) sel.replaceWith(assignBtn); });
+        assignBtn.replaceWith(sel);
+        sel.focus();
+      });
+      children.push(assignBtn);
+    }
+
     const deleteBtn = this._el("button", {
       className: "delete-task-btn",
       textContent: this._t("delete_task"),
     });
     deleteBtn.addEventListener("click", () => this._deleteTask(task.id, colIdx));
-    return this._el("div", { className: "detail-actions" }, [deleteBtn]);
+    children.push(deleteBtn);
+
+    return this._el("div", { className: "detail-actions" }, children);
+  }
+
+  async _duplicateAndAssign(task, colIdx, assignedPerson) {
+    const listId = this._colListId(colIdx);
+    const newTask = await this._callWs("home_tasks/duplicate_task", {
+      list_id: listId,
+      task_id: task.id,
+      assigned_person: assignedPerson,
+    });
+    if (!newTask) return;
+    const cs = this._columns[colIdx];
+    if (cs && cs.tasks) cs.tasks.push(newTask);
+    this._render();
+    this._loadAllTasks();
   }
 
   _buildImageSection(task, colIdx) {
@@ -6207,12 +6269,23 @@ class HomeTasksCard extends HTMLElement {
       .history-text { color: var(--primary-text-color); }
       .history-ts { color: var(--secondary-text-color); white-space: nowrap; font-size: 11px; }
       .history-empty { margin: 0; font-size: 12px; color: var(--secondary-text-color); }
-      .detail-actions { display: flex; justify-content: flex-end; padding-top: 4px; }
+      .detail-actions { display: flex; justify-content: flex-end; padding-top: 4px; gap: 8px; }
       .delete-task-btn {
         background: none; border: 1px solid var(--todo-error); color: var(--todo-error);
         padding: 6px 14px; border-radius: 4px; font-size: 12px; cursor: pointer; font-family: inherit;
       }
       .delete-task-btn:hover { background: rgba(244, 67, 54, 0.15); }
+      .assign-copy-btn {
+        background: none; border: 1px solid var(--todo-primary); color: var(--todo-primary);
+        padding: 6px 14px; border-radius: 4px; font-size: 12px; cursor: pointer; font-family: inherit;
+        margin-right: auto;
+      }
+      .assign-copy-btn:hover { background: rgba(var(--rgb-primary-color, 3,169,244), 0.1); }
+      .assign-copy-sel {
+        border: 1px solid var(--todo-primary); color: var(--todo-primary);
+        background: var(--todo-bg); padding: 6px 8px; border-radius: 4px; font-size: 12px;
+        cursor: pointer; font-family: inherit; margin-right: auto;
+      }
 
       /* --- Task image --- */
       .task-thumb {

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -4997,22 +4997,109 @@ class HomeTasksCard extends HTMLElement {
     ]);
   }
 
-  _openMediaPicker(task, colIdx) {
-    this.dispatchEvent(new CustomEvent("show-dialog", {
-      bubbles: true,
-      composed: true,
-      detail: {
-        dialogTag: "dialog-media-player-browse",
-        dialogParams: {
-          action: "pick",
-          navigateIds: [{ params: {}, id: "media-source://media_source" }],
-          mediaPickedCallback: (item) => {
-            const url = item?.media_content_id;
-            if (url) this._saveImageUrl(task, colIdx, url);
-          },
-        },
-      },
-    }));
+  async _openMediaPicker(task, colIdx) {
+    const navStack = []; // { id, title }
+
+    const dialog = document.createElement("dialog");
+    dialog.className = "mb-dialog";
+
+    const header = this._el("div", { className: "mb-header" }, [
+      this._el("span", { className: "mb-title", textContent: "Mediathek" }),
+    ]);
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "mb-close";
+    const closeIco = document.createElement("ha-icon");
+    closeIco.setAttribute("icon", "mdi:close");
+    closeIco.style.cssText = "--mdc-icon-size:20px;";
+    closeBtn.appendChild(closeIco);
+    closeBtn.addEventListener("click", () => { dialog.close(); dialog.remove(); });
+    header.appendChild(closeBtn);
+
+    const list = this._el("div", { className: "mb-list" });
+
+    const load = async (id) => {
+      list.innerHTML = `<div class="mb-status">Lädt…</div>`;
+      try {
+        const data = await this._hass.callWS({
+          type: "media_source/browse_media",
+          media_content_id: id,
+        });
+        list.innerHTML = "";
+
+        if (navStack.length > 0) {
+          const prev = navStack[navStack.length - 1];
+          const backBtn = document.createElement("button");
+          backBtn.className = "mb-item mb-back";
+          const backIco = document.createElement("ha-icon");
+          backIco.setAttribute("icon", "mdi:arrow-left");
+          backIco.style.cssText = "--mdc-icon-size:20px;flex-shrink:0;";
+          backBtn.append(backIco, prev.title);
+          backBtn.addEventListener("click", () => { navStack.pop(); load(prev.id); });
+          list.appendChild(backBtn);
+        }
+
+        const crumb = this._el("div", { className: "mb-crumb", textContent: data.title || "Medien" });
+        list.appendChild(crumb);
+
+        for (const item of (data.children || [])) {
+          const row = document.createElement("button");
+          row.className = "mb-item" + (item.can_expand ? " mb-folder" : "");
+
+          if (item.thumbnail) {
+            const img = this._el("img", { className: "mb-thumb", src: item.thumbnail, alt: "" });
+            row.appendChild(img);
+          } else {
+            const ico = document.createElement("ha-icon");
+            const iconMap = { directory: "mdi:folder", image: "mdi:image", music: "mdi:music-note", video: "mdi:video" };
+            ico.setAttribute("icon", iconMap[item.media_class] || "mdi:file");
+            ico.style.cssText = "--mdc-icon-size:24px;flex-shrink:0;color:var(--secondary-text-color);";
+            row.appendChild(ico);
+          }
+
+          row.appendChild(this._el("span", { className: "mb-item-title", textContent: item.title }));
+
+          if (item.can_expand) {
+            const chev = document.createElement("ha-icon");
+            chev.setAttribute("icon", "mdi:chevron-right");
+            chev.style.cssText = "--mdc-icon-size:18px;flex-shrink:0;color:var(--secondary-text-color);";
+            row.appendChild(chev);
+          }
+
+          row.addEventListener("click", async () => {
+            if (item.can_expand) {
+              navStack.push({ id, title: data.title || "Zurück" });
+              await load(item.media_content_id);
+            } else {
+              try {
+                const resolved = await this._hass.callWS({
+                  type: "media_source/resolve_media",
+                  media_content_id: item.media_content_id,
+                });
+                await this._saveImageUrl(task, colIdx, resolved.url || item.thumbnail);
+              } catch {
+                if (item.thumbnail) await this._saveImageUrl(task, colIdx, item.thumbnail);
+              }
+              dialog.close();
+              dialog.remove();
+            }
+          });
+
+          list.appendChild(row);
+        }
+
+        if (!data.children?.length) {
+          list.appendChild(this._el("div", { className: "mb-status", textContent: "Keine Dateien" }));
+        }
+      } catch (e) {
+        list.innerHTML = `<div class="mb-status mb-error">Fehler: ${e.message || e}</div>`;
+      }
+    };
+
+    dialog.append(header, list);
+    dialog.addEventListener("close", () => dialog.remove());
+    this.shadowRoot.appendChild(dialog);
+    dialog.showModal();
+    await load("media-source://media_source");
   }
 
   async _generateTaskImage(task, colIdx, force = false) {
@@ -6209,6 +6296,51 @@ class HomeTasksCard extends HTMLElement {
       .tile-dialog-cancel:hover { background: color-mix(in srgb, var(--primary-color) 10%, transparent); }
       .tile-dialog-confirm { background: var(--primary-color); color: var(--text-primary-color, #fff); }
       .tile-dialog-confirm:hover { filter: brightness(1.08); }
+
+      /* Media browser dialog */
+      dialog.mb-dialog {
+        padding: 0; border: none; border-radius: 12px;
+        width: min(480px, 95vw); max-height: 70vh;
+        display: flex; flex-direction: column;
+        background: var(--ha-card-background, var(--card-background-color, #fff));
+        color: var(--primary-text-color);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.32);
+        overflow: hidden;
+      }
+      dialog.mb-dialog::backdrop { background: rgba(0,0,0,0.5); }
+      .mb-header {
+        display: flex; align-items: center; gap: 8px;
+        padding: 16px 8px 16px 20px; flex-shrink: 0;
+        border-bottom: 1px solid var(--divider-color, rgba(0,0,0,0.12));
+      }
+      .mb-title { flex: 1; font-size: 18px; font-weight: 500; }
+      .mb-close {
+        background: none; border: none; cursor: pointer;
+        color: var(--secondary-text-color); padding: 8px; border-radius: 50%;
+        display: flex; align-items: center;
+      }
+      .mb-close:hover { background: var(--secondary-background-color); }
+      .mb-list { overflow-y: auto; flex: 1; }
+      .mb-status { padding: 32px; text-align: center; color: var(--secondary-text-color); font-size: 14px; }
+      .mb-error { color: var(--error-color, #db4437); }
+      .mb-crumb {
+        padding: 8px 16px 4px; font-size: 11px; font-weight: 600;
+        color: var(--secondary-text-color); text-transform: uppercase; letter-spacing: 0.6px;
+      }
+      .mb-item {
+        display: flex; align-items: center; gap: 12px;
+        width: 100%; padding: 10px 16px;
+        background: none; border: none; border-bottom: 1px solid var(--divider-color, rgba(0,0,0,0.06));
+        cursor: pointer; color: var(--primary-text-color);
+        font-family: inherit; font-size: 14px; text-align: left;
+      }
+      .mb-item:hover { background: var(--secondary-background-color, rgba(0,0,0,0.04)); }
+      .mb-back {
+        color: var(--primary-color); font-weight: 500;
+        border-bottom: 2px solid var(--divider-color, rgba(0,0,0,0.12));
+      }
+      .mb-thumb { width: 40px; height: 40px; object-fit: cover; border-radius: 4px; flex-shrink: 0; }
+      .mb-item-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
       /* Compact tile variant */
       .compact .tile-grid-inner { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 7px; }

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -5000,10 +5000,7 @@ class HomeTasksCard extends HTMLElement {
       composed: true,
       detail: {
         dialogTag: "ha-media-player-browse-dialog",
-        dialogImport: () =>
-          customElements.get("ha-media-player-browse-dialog")
-            ? Promise.resolve()
-            : import("/frontend_latest/chunk.js").catch(() => Promise.resolve()),
+        dialogImport: () => customElements.whenDefined("ha-media-player-browse-dialog"),
         dialogParams: {
           action: "pick",
           navigateIds: [{ params: {}, id: "media-source://media_source" }],

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -6346,6 +6346,8 @@ class HomeTasksCard extends HTMLElement {
       }
       .sheet-close:hover { background: var(--secondary-background-color); }
       .sheet-body { overflow-y: auto; flex: 1; padding: 12px 0 8px; }
+      .sheet-body .task-details { height: auto; border-top: none; }
+      .sheet-body .task-details-inner { padding: 0 16px 16px; }
       .tile-title {
         color: #fff; font-size: 12px; font-weight: 600; line-height: 1.3;
         text-shadow: 0 1px 4px rgba(0,0,0,0.5);

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -2934,12 +2934,71 @@ class HomeTasksCard extends HTMLElement {
       tile.appendChild(overlay);
     }
 
-    // Tap anywhere on the tile = toggle complete (no detail opening)
-    tile.addEventListener("click", (e) => {
+    // Short tap = toggle complete; long press (500 ms) = open detail sheet
+    let _lpTimer = null;
+    let _lpFired = false;
+    let _lpStartX = 0;
+    let _lpStartY = 0;
+
+    tile.addEventListener("pointerdown", (e) => {
+      if (e.button !== 0) return;
+      _lpFired = false;
+      _lpStartX = e.clientX;
+      _lpStartY = e.clientY;
+      _lpTimer = setTimeout(() => {
+        _lpFired = true;
+        tile.releasePointerCapture(e.pointerId);
+        this._openTaskDetailSheet(task, colIdx);
+      }, 500);
+    });
+
+    const _lpCancel = () => { clearTimeout(_lpTimer); _lpTimer = null; };
+    tile.addEventListener("pointermove", (e) => {
+      if (_lpTimer && (Math.abs(e.clientX - _lpStartX) > 8 || Math.abs(e.clientY - _lpStartY) > 8)) _lpCancel();
+    });
+    tile.addEventListener("pointerup", _lpCancel);
+    tile.addEventListener("pointercancel", _lpCancel);
+
+    tile.addEventListener("click", () => {
+      if (_lpFired) { _lpFired = false; return; }
       this._toggleTask(task.id, task.completed, colIdx);
     });
 
     return tile;
+  }
+
+  _openTaskDetailSheet(task, colIdx) {
+    this.shadowRoot.querySelector(".task-detail-sheet")?.remove();
+    this.shadowRoot.querySelector(".task-detail-backdrop")?.remove();
+
+    const backdrop = this._el("div", { className: "task-detail-backdrop" });
+    const sheet = this._el("div", { className: "task-detail-sheet" });
+
+    const close = () => {
+      sheet.classList.remove("open");
+      sheet.addEventListener("transitionend", () => { sheet.remove(); backdrop.remove(); }, { once: true });
+      setTimeout(() => { sheet.remove(); backdrop.remove(); }, 350);
+    };
+
+    backdrop.addEventListener("click", close);
+
+    const handle = this._el("div", { className: "sheet-handle" });
+    const titleEl = this._el("span", { className: "sheet-title", textContent: task.title });
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "sheet-close";
+    const closeIco = document.createElement("ha-icon");
+    closeIco.setAttribute("icon", "mdi:close");
+    closeIco.style.cssText = "--mdc-icon-size:20px;";
+    closeBtn.appendChild(closeIco);
+    closeBtn.addEventListener("click", close);
+    const header = this._el("div", { className: "sheet-header" }, [titleEl, closeBtn]);
+
+    const body = this._el("div", { className: "sheet-body" });
+    body.appendChild(this._buildTaskDetails(task, colIdx));
+
+    sheet.append(handle, header, body);
+    this.shadowRoot.append(backdrop, sheet);
+    requestAnimationFrame(() => requestAnimationFrame(() => sheet.classList.add("open")));
   }
 
   _buildFilterBtn(label, value, colIdx) {
@@ -5619,6 +5678,13 @@ class HomeTasksCard extends HTMLElement {
       // they want to focus / select / scroll the field, not drag the task.
       if (this._isInteractiveTarget(e.target)) return;
       const touch = e.touches[0];
+      let lpStartX = touch.clientX, lpStartY = touch.clientY;
+      this._touchLpTimer = setTimeout(() => {
+        this._touchLpTimer = null;
+        if (this._touchStartTimer) { clearTimeout(this._touchStartTimer); this._touchStartTimer = null; }
+        if (this._draggedTaskId) { this._finishDrag(); }
+        this._openTaskDetailSheet(task, colIdx);
+      }, 500);
       this._touchStartTimer = setTimeout(() => {
         this._draggedTaskId = taskId;
         this._draggedColIdx = colIdx;
@@ -5646,6 +5712,15 @@ class HomeTasksCard extends HTMLElement {
         this._touchClone = clone;
         this._touchOffsetY = touch.clientY - rect.top;
       }, 150);
+      // Cancel long-press on significant movement
+      const _cancelLp = (ev) => {
+        const t = ev.touches[0];
+        if (Math.abs(t.clientX - lpStartX) > 8 || Math.abs(t.clientY - lpStartY) > 8) {
+          if (this._touchLpTimer) { clearTimeout(this._touchLpTimer); this._touchLpTimer = null; }
+          taskEl.removeEventListener("touchmove", _cancelLp);
+        }
+      };
+      taskEl.addEventListener("touchmove", _cancelLp, { passive: true });
     }, { passive: true });
 
     const onTouchMove = (e) => {
@@ -5682,6 +5757,7 @@ class HomeTasksCard extends HTMLElement {
     };
 
     const onTouchEnd = () => {
+      if (this._touchLpTimer) { clearTimeout(this._touchLpTimer); this._touchLpTimer = null; }
       if (this._touchStartTimer) {
         clearTimeout(this._touchStartTimer);
         this._touchStartTimer = null;
@@ -6235,6 +6311,41 @@ class HomeTasksCard extends HTMLElement {
       .task-tile:not(.has-image) .tile-overlay {
         background: linear-gradient(transparent, rgba(0,0,0,0.25));
       }
+
+      /* Task detail bottom sheet (tile long-press) */
+      .task-detail-backdrop {
+        position: fixed; inset: 0; z-index: 998;
+        background: rgba(0,0,0,0.32);
+      }
+      .task-detail-sheet {
+        position: fixed; bottom: 0; left: 0; right: 0; z-index: 999;
+        background: var(--ha-card-background, var(--card-background-color, #1c1c1c));
+        border-radius: 16px 16px 0 0;
+        box-shadow: 0 -4px 24px rgba(0,0,0,0.28);
+        transform: translateY(100%);
+        transition: transform 0.28s cubic-bezier(0.32, 0.72, 0, 1);
+        max-height: 85vh;
+        display: flex; flex-direction: column;
+        padding-bottom: env(safe-area-inset-bottom, 0);
+      }
+      .task-detail-sheet.open { transform: translateY(0); }
+      .sheet-handle {
+        width: 40px; height: 4px; border-radius: 2px;
+        background: var(--divider-color, rgba(255,255,255,0.2));
+        margin: 10px auto 4px; flex-shrink: 0;
+      }
+      .sheet-header {
+        display: flex; align-items: center; gap: 8px;
+        padding: 8px 8px 12px 20px; flex-shrink: 0;
+        border-bottom: 1px solid var(--divider-color, rgba(255,255,255,0.08));
+      }
+      .sheet-title { flex: 1; font-size: 16px; font-weight: 500; color: var(--primary-text-color); }
+      .sheet-close {
+        background: none; border: none; cursor: pointer; border-radius: 50%;
+        color: var(--secondary-text-color); padding: 8px; display: flex; align-items: center;
+      }
+      .sheet-close:hover { background: var(--secondary-background-color); }
+      .sheet-body { overflow-y: auto; flex: 1; padding: 12px 0 8px; }
       .tile-title {
         color: #fff; font-size: 12px; font-weight: 600; line-height: 1.3;
         text-shadow: 0 1px 4px rgba(0,0,0,0.5);

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -5,7 +5,7 @@
  * Security: All user-controlled content is set via textContent or DOM properties,
  * never via innerHTML with unsanitized data.
  */
-console.info("%c HOME-TASKS-CARD %c v1.13.1 ", "color: white; background: #03a9f4; font-weight: bold;", "color: #03a9f4; background: white; font-weight: bold;");
+console.info("%c HOME-TASKS-CARD %c v1.14.0 ", "color: white; background: #03a9f4; font-weight: bold;", "color: #03a9f4; background: white; font-weight: bold;");
 
 const _TRANSLATIONS = {
   en: {
@@ -115,6 +115,8 @@ const _TRANSLATIONS = {
     history: "History", history_created: "Created", history_completed: "Completed", history_reopened: "Reopened",
     history_reset: "Auto-reset (recurrence)", history_changed: "changed", history_empty: "No history yet", hist_title: "Title", history_disabled: "Disabled",
     ed_show_history: "Histories", hist_by_user: "User",
+    ed_view_mode: "View mode", ed_view_mode_list: "List", ed_view_mode_tiles: "Tiles",
+    ed_show_tile_title: "Title in tiles",
     assigned_unknown: "Unknown (%s)", recurrence_readonly: "Managed by %s", synced_with: "Synced with %s",
     due_today: "Today", due_tomorrow: "Tomorrow", due_yesterday: "Yesterday",
     due_day_after_tomorrow: "In 2 days", due_day_before_yesterday: "2 days ago",
@@ -1102,6 +1104,8 @@ const _TRANSLATIONS = {
     history: "Verlauf", history_created: "Erstellt", history_completed: "Erledigt", history_reopened: "Wieder ge\u00f6ffnet",
     history_reset: "Automatisch zur\u00fcckgesetzt", history_changed: "ge\u00e4ndert", history_empty: "Noch kein Verlauf", hist_title: "Titel", history_disabled: "Deaktiviert",
     ed_show_history: "Verläufe", hist_by_user: "Benutzer",
+    ed_view_mode: "Ansichtsmodus", ed_view_mode_list: "Liste", ed_view_mode_tiles: "Kacheln",
+    ed_show_tile_title: "Titel in Kacheln",
     assigned_unknown: "Unbekannt (%s)", recurrence_readonly: "Verwaltet von %s", synced_with: "Synchronisiert mit %s",
     due_today: "Heute", due_tomorrow: "Morgen", due_yesterday: "Gestern",
     due_day_after_tomorrow: "\u00dcbermorgen", due_day_before_yesterday: "Vorgestern",
@@ -2462,17 +2466,20 @@ class HomeTasksCard extends HTMLElement {
       ? this._el("div", { className: "person-chips-row" }, [personChips, sortBtnWrapper])
       : personChips;
 
-    const taskList = this._buildColumnTaskList(filteredTasks, colIdx);
+    const isTiles = col.view_mode === "tiles";
+    const taskList = isTiles
+      ? this._buildColumnTileGrid(filteredTasks, colIdx)
+      : this._buildColumnTaskList(filteredTasks, colIdx);
 
     const children = [];
     if (header) children.push(header);
-    children.push(addTask);
-    if (filters) children.push(filters);
-    if (tagChipsEl) children.push(tagChipsEl);
-    if (personChipsEl) children.push(personChipsEl);
+    if (!isTiles) children.push(addTask);
+    if (!isTiles && filters) children.push(filters);
+    if (!isTiles && tagChipsEl) children.push(tagChipsEl);
+    if (!isTiles && personChipsEl) children.push(personChipsEl);
     children.push(taskList);
 
-    const className = "card-column" + (col.compact === true ? " compact" : "");
+    const className = "card-column" + (col.compact === true ? " compact" : "") + (isTiles ? " tiles-mode" : "");
     return this._el("div", { className }, children);
   }
 
@@ -2779,6 +2786,74 @@ class HomeTasksCard extends HTMLElement {
       this._finishDrag();
     });
     return taskList;
+  }
+
+  // ── Tile / Kachel view ─────────────────────────────────────────────────────
+
+  _buildColumnTileGrid(filteredTasks, colIdx) {
+    const col = this._config.columns[colIdx];
+
+    if (filteredTasks.length === 0) {
+      const empty = this._el("div", { className: "empty-state", textContent: this._t("empty") });
+      return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [empty]);
+    }
+
+    // Open tasks first, completed after
+    const openTasks = filteredTasks.filter(t => !t.completed);
+    const doneTasks = filteredTasks.filter(t => t.completed);
+    const ordered = [...openTasks, ...doneTasks];
+
+    const tileEls = ordered.map(task => this._buildTaskTile(task, colIdx));
+    const grid = this._el("div", { className: "tile-grid-inner" }, tileEls);
+    return this._el("div", { className: "tile-grid-wrap", "data-col-idx": String(colIdx) }, [grid]);
+  }
+
+  _buildTaskTile(task, colIdx) {
+    const col = this._config.columns[colIdx];
+    // Use image_url if available (populated once the image feature is enabled)
+    const thumbUrl = task.image_url || null;
+
+    const cls = [
+      "task-tile",
+      task.completed ? "completed" : "",
+      thumbUrl ? "has-image" : "",
+    ].filter(Boolean).join(" ");
+
+    const tile = this._el("div", { className: cls });
+
+    if (thumbUrl) {
+      const img = this._el("img", { className: "tile-bg", src: thumbUrl, alt: "" });
+      tile.appendChild(img);
+    } else {
+      // Placeholder: first letter on gradient background
+      const placeholder = this._el("div", {
+        className: "tile-placeholder",
+        textContent: (task.title || "?").charAt(0).toUpperCase(),
+      });
+      tile.appendChild(placeholder);
+    }
+
+    // Bottom overlay: title (optional) + done badge
+    const showTitle = col.show_tile_title !== false;
+    if (showTitle || task.completed) {
+      const overlay = this._el("div", { className: "tile-overlay" });
+      if (showTitle) {
+        const titleEl = this._el("div", { className: "tile-title", textContent: task.title || "" });
+        overlay.appendChild(titleEl);
+      }
+      if (task.completed) {
+        const badge = this._el("div", { className: "tile-done-badge", textContent: "✓" });
+        overlay.appendChild(badge);
+      }
+      tile.appendChild(overlay);
+    }
+
+    // Tap anywhere on the tile = toggle complete (no detail opening)
+    tile.addEventListener("click", () => {
+      this._toggleTask(task.id, task.completed, colIdx);
+    });
+
+    return tile;
   }
 
   _buildFilterBtn(label, value, colIdx) {
@@ -5730,6 +5805,63 @@ class HomeTasksCard extends HTMLElement {
       .compact .empty-state { padding: 16px; font-size: 13px; }
       .compact .task-details-inner { padding: 8px 10px; }
 
+      /* ── Tile / Kachel view ──────────────────────────────────── */
+      .tile-grid-wrap { display: flex; flex-direction: column; gap: 12px; padding: 4px 0; }
+      .tile-grid-inner {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 10px;
+      }
+      .task-tile {
+        position: relative; border-radius: 14px; overflow: hidden;
+        aspect-ratio: 1 / 1; cursor: pointer;
+        background: var(--todo-surface);
+        border: 1px solid var(--todo-divider);
+        transition: transform 0.18s ease, box-shadow 0.18s ease;
+        user-select: none;
+      }
+      .task-tile:hover { transform: scale(1.04); box-shadow: 0 6px 18px rgba(0,0,0,0.15); }
+      .task-tile.selected { outline: 2.5px solid var(--todo-primary); outline-offset: 2px; }
+      .task-tile.completed { opacity: 0.50; }
+      .tile-bg {
+        width: 100%; height: 100%; object-fit: cover; display: block;
+        position: absolute; inset: 0;
+      }
+      .tile-placeholder {
+        width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;
+        font-size: 2.8rem; font-weight: 700; color: var(--todo-disabled);
+        background: linear-gradient(135deg, var(--todo-surface) 0%, var(--todo-divider) 100%);
+        position: absolute; inset: 0;
+      }
+      .tile-overlay {
+        position: absolute; bottom: 0; left: 0; right: 0; z-index: 2;
+        padding: 24px 9px 9px;
+        background: linear-gradient(transparent, rgba(0,0,0,0.68));
+        display: flex; align-items: flex-end; justify-content: space-between; gap: 4px;
+      }
+      .task-tile:not(.has-image) .tile-overlay {
+        background: linear-gradient(transparent, rgba(0,0,0,0.25));
+      }
+      .tile-title {
+        color: #fff; font-size: 12px; font-weight: 600; line-height: 1.3;
+        text-shadow: 0 1px 4px rgba(0,0,0,0.5);
+        display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+        flex: 1;
+      }
+      .task-tile:not(.has-image) .tile-title { color: var(--todo-text); text-shadow: none; }
+      .tile-done-badge {
+        color: #fff; font-weight: 700; flex-shrink: 0;
+        background: rgba(67,160,71,0.85); border-radius: 50%;
+        width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;
+        font-size: 11px;
+      }
+      .tiles-mode { padding: 12px; }
+
+      /* Compact tile variant */
+      .compact .tile-grid-inner { grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 7px; }
+      .compact .task-tile { border-radius: 10px; }
+      .compact .tile-title { font-size: 11px; }
+
       @keyframes task-exit {
         0%   { opacity: 1; transform: translateY(0); }
         100% { opacity: 0; transform: translateY(-8px); }
@@ -6519,8 +6651,15 @@ class HomeTasksCardEditor extends HTMLElement {
           makeToggle("show-sort", "ed_show_sort", "show_sort", true),
           makeToggle("compact", "ed_compact", "compact", false),
           makeToggle("show-history", "ed_show_history", "show_history", false),
+          makeToggle("show-tile-title", "ed_show_tile_title", "show_tile_title", true),
         ]),
         sortField,
+        makeSelect(
+          "ed_view_mode",
+          [["list", "ed_view_mode_list"], ["tiles", "ed_view_mode_tiles"]],
+          col.view_mode || "list",
+          (val) => updateCol({ view_mode: val === "list" ? undefined : val })
+        ),
       ]),
       makeSection("filters", "mdi:filter-variant", "ed_sec_filters", [
         filterField,

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -6747,31 +6747,31 @@ class HomeTasksCardEditor extends HTMLElement {
 
   _buildImgGenSection() {
     const imgGen = this._config.image_generation || {};
-    const updateImgGen = (patch) => {
-      const merged = { ...imgGen, ...patch };
-      Object.keys(merged).forEach(k => merged[k] === undefined && delete merged[k]);
+
+    const form = document.createElement("ha-form");
+    form.hass = this._hass;
+    form.data = { entity_id: imgGen.entity_id || "", prompt_prefix: imgGen.prompt_prefix || "" };
+    form.schema = [
+      {
+        name: "entity_id",
+        selector: { entity: { domain: ["ai_task"] } },
+      },
+      {
+        name: "prompt_prefix",
+        selector: { text: {} },
+      },
+    ];
+    form.computeLabel = (schema) =>
+      schema.name === "entity_id" ? this._t("ed_ai_image_entity")
+      : schema.name === "prompt_prefix" ? this._t("ed_ai_prompt_prefix")
+      : schema.name;
+    form.addEventListener("value-changed", (e) => {
+      const val = e.detail.value || {};
+      const merged = {};
+      if (val.entity_id) merged.entity_id = val.entity_id;
+      if (val.prompt_prefix) merged.prompt_prefix = val.prompt_prefix;
       this._config = { ...this._config, image_generation: Object.keys(merged).length ? merged : undefined };
       this._fireChanged();
-    };
-
-    const entityPicker = document.createElement("ha-entity-picker");
-    entityPicker.hass = this._hass;
-    entityPicker.label = this._t("ed_ai_image_entity");
-    entityPicker.value = imgGen.entity_id || "";
-    entityPicker.includeDomains = ["ai_task"];
-    entityPicker.allowCustomEntity = true;
-    entityPicker.style.width = "100%";
-    entityPicker.addEventListener("value-changed", (e) => {
-      updateImgGen({ entity_id: e.detail.value || undefined });
-    });
-
-    const promptField = document.createElement("ha-textfield");
-    promptField.label = this._t("ed_ai_prompt_prefix");
-    promptField.placeholder = this._t("ed_ai_prompt_prefix_placeholder");
-    promptField.value = imgGen.prompt_prefix || "";
-    promptField.style.width = "100%";
-    promptField.addEventListener("change", (e) => {
-      updateImgGen({ prompt_prefix: e.target.value.trim() || undefined });
     });
 
     const det = document.createElement("details");
@@ -6780,7 +6780,6 @@ class HomeTasksCardEditor extends HTMLElement {
       this._sectionOpen = { ...(this._sectionOpen || {}), imggen: det.open };
     });
     const sum = document.createElement("summary");
-    sum.className = "editor-section-summary";
     const ico = document.createElement("ha-icon");
     ico.setAttribute("icon", "mdi:image-spark");
     ico.style.cssText = "--mdc-icon-size:20px;width:20px;height:20px;flex-shrink:0;";
@@ -6791,7 +6790,7 @@ class HomeTasksCardEditor extends HTMLElement {
     chev.style.cssText = "--mdc-icon-size:20px;width:20px;height:20px;";
     sum.append(ico, lbl, chev);
     det.appendChild(sum);
-    det.appendChild(this._el("div", { className: "section-content" }, [entityPicker, promptField]));
+    det.appendChild(this._el("div", { className: "section-content" }, [form]));
     return det;
   }
 

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -1202,6 +1202,7 @@ class HomeTasksCard extends HTMLElement {
     // takes over) or they pick "Ab Erledigung" (which clears the override).
     this._weekPatternOverride = new Map();   // task.id → "on"
     this._yearPatternOverride = new Map();   // task.id → "on"
+    this._generatingImage = new Set();       // task IDs currently generating
   }
 
   _defaultColState() {
@@ -3270,6 +3271,15 @@ class HomeTasksCard extends HTMLElement {
         this._render();
       });
       children.push(titleSpan);
+      // Thumbnail in task row if image exists
+      if (task.image_url) {
+        children.push(this._el("img", {
+          className: "task-thumb",
+          src: task.image_url,
+          alt: "",
+          title: task.title,
+        }));
+      }
     }
     return children;
   }
@@ -3577,6 +3587,7 @@ class HomeTasksCard extends HTMLElement {
     if (col.show_reminders !== false) details.push(this._buildRemindersSection(task, colIdx));
     if (col.show_recurrence !== false) details.push(this._buildRecurrenceSection(task, colIdx));
     if (col.show_history) details.push(this._buildHistorySection(task));
+    if (!this._isExternalCol(colIdx)) details.push(this._buildImageSection(task, colIdx));
     details.push(this._buildActionsSection(task, colIdx));
 
     const inner = this._el("div", { className: "task-details-inner" }, details);
@@ -4883,6 +4894,94 @@ class HomeTasksCard extends HTMLElement {
     return this._el("div", { className: "detail-actions" }, [deleteBtn]);
   }
 
+  _buildImageSection(task, colIdx) {
+    const col = this._config.columns[colIdx];
+    const imgCfg = this._config.image_generation || {};
+    const isGenerating = this._generatingImage.has(task.id);
+
+    const children = [];
+
+    // --- Show existing image ---
+    if (task.image_url) {
+      const imgWrap = this._el("div", { className: "task-image-wrap" });
+
+      const img = this._el("img", { className: "task-image", src: task.image_url, alt: task.title });
+      imgWrap.appendChild(img);
+
+      // Remove image button (×)
+      const removeBtn = this._el("button", {
+        className: "task-image-remove",
+        title: "Bild entfernen",
+        innerHTML: "×",
+      });
+      removeBtn.addEventListener("click", async () => {
+        await this._hass.callWS({
+          type: "home_tasks/update_task",
+          entry_id: col.entry_id,
+          task_id: task.id,
+          image_url: null,
+        });
+        this._render();
+      });
+      imgWrap.appendChild(removeBtn);
+      children.push(imgWrap);
+    }
+
+    // --- Generate button ---
+    const genBtn = this._el("button", {
+      className: "generate-image-btn" + (isGenerating ? " generating" : ""),
+      disabled: isGenerating,
+    });
+    if (isGenerating) {
+      genBtn.innerHTML = `<span class="spinner"></span> Generiere…`;
+    } else {
+      genBtn.innerHTML = `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" style="margin-right:6px;vertical-align:-3px"><path d="M12 2a10 10 0 100 20A10 10 0 0012 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>${task.image_url ? "Bild neu generieren" : "✨ Bild generieren"}`;
+    }
+    genBtn.addEventListener("click", () => this._generateTaskImage(task, colIdx));
+    children.push(genBtn);
+
+    return this._el("div", { className: "detail-section detail-section--image" }, [
+      this._el("label", { className: "detail-label", textContent: "Bild" }),
+      this._el("div", { className: "image-section-body" }, children),
+    ]);
+  }
+
+  async _generateTaskImage(task, colIdx) {
+    const col = this._config.columns[colIdx];
+    const imgCfg = this._config.image_generation || {};
+
+    this._generatingImage.add(task.id);
+    this._render();
+
+    const payload = {
+      type: "home_tasks/generate_task_image",
+      entry_id: col.entry_id,
+      task_id: task.id,
+    };
+    if (imgCfg.api_key) payload.api_key = imgCfg.api_key;
+    if (imgCfg.endpoint) payload.endpoint = imgCfg.endpoint;
+    if (imgCfg.model) payload.model = imgCfg.model;
+    if (imgCfg.size) payload.size = imgCfg.size;
+    if (imgCfg.quality) payload.quality = imgCfg.quality;
+    if (imgCfg.prompt_prefix) payload.prompt_prefix = imgCfg.prompt_prefix;
+
+    try {
+      const result = await this._hass.callWS(payload);
+      // Update local task state immediately so image shows without full reload
+      const cs = this._columns[colIdx];
+      if (cs && cs.tasks) {
+        const idx = cs.tasks.findIndex(t => t.id === task.id);
+        if (idx >= 0) cs.tasks[idx] = result.task;
+      }
+    } catch (err) {
+      console.error("Image generation failed:", err);
+      alert("Bildgenerierung fehlgeschlagen: " + (err.message || err));
+    } finally {
+      this._generatingImage.delete(task.id);
+      this._render();
+    }
+  }
+
   _buildHistorySection(task) {
     const taskHistory = (task.history || []).slice().reverse();
     const histContent = this._el("div", { className: "history-list" });
@@ -5838,6 +5937,50 @@ class HomeTasksCard extends HTMLElement {
         padding: 6px 14px; border-radius: 4px; font-size: 12px; cursor: pointer; font-family: inherit;
       }
       .delete-task-btn:hover { background: rgba(244, 67, 54, 0.15); }
+
+      /* --- Task image --- */
+      .task-thumb {
+        width: 36px; height: 36px; border-radius: 4px; object-fit: cover;
+        flex-shrink: 0; margin-left: 6px; opacity: 0.85; transition: opacity 0.2s;
+        cursor: pointer;
+      }
+      .task-thumb:hover { opacity: 1; }
+      .detail-section--image .image-section-body { display: flex; flex-direction: column; gap: 10px; }
+      .task-image-wrap {
+        position: relative; display: inline-block; width: 100%;
+        border-radius: 8px; overflow: hidden;
+        max-height: 300px;
+      }
+      .task-image {
+        width: 100%; max-height: 300px; object-fit: cover;
+        border-radius: 8px; display: block;
+      }
+      .task-image-remove {
+        position: absolute; top: 6px; right: 6px; width: 24px; height: 24px;
+        border-radius: 50%; background: rgba(0,0,0,0.55); color: #fff;
+        border: none; font-size: 16px; line-height: 1; cursor: pointer;
+        display: flex; align-items: center; justify-content: center;
+        transition: background 0.15s;
+      }
+      .task-image-remove:hover { background: rgba(0,0,0,0.8); }
+      .generate-image-btn {
+        display: inline-flex; align-items: center; padding: 7px 14px;
+        border: 1px solid var(--todo-primary); background: transparent;
+        color: var(--todo-primary); border-radius: var(--todo-radius);
+        font-size: 13px; cursor: pointer; font-family: inherit;
+        transition: background 0.15s, opacity 0.15s;
+      }
+      .generate-image-btn:hover:not(:disabled) { background: rgba(var(--rgb-primary-color, 33,150,243), 0.1); }
+      .generate-image-btn:disabled { opacity: 0.6; cursor: default; }
+      .generate-image-btn.generating { border-style: dashed; }
+      .spinner {
+        display: inline-block; width: 14px; height: 14px;
+        border: 2px solid currentColor; border-top-color: transparent;
+        border-radius: 50%; animation: spin 0.7s linear infinite;
+        margin-right: 6px; flex-shrink: 0;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+
       .toast-error {
         position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
         background: var(--todo-error, #db4437); color: #fff; padding: 10px 20px;

--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -5141,7 +5141,9 @@ class HomeTasksCard extends HTMLElement {
             const cell = document.createElement("button");
             cell.className = "mb-grid-item";
             if (item.thumbnail) {
-              cell.appendChild(this._el("img", { className: "mb-grid-thumb", src: item.thumbnail, alt: item.title }));
+              const img = this._el("img", { className: "mb-grid-thumb", alt: item.title });
+              this._fetchAuthThumb(item.thumbnail).then(src => { img.src = src; });
+              cell.appendChild(img);
             } else {
               const ico = document.createElement("ha-icon");
               ico.setAttribute("icon", "mdi:image");
@@ -5201,6 +5203,21 @@ class HomeTasksCard extends HTMLElement {
       this._generatingImage.delete(task.id);
       this._render();
     }
+  }
+
+  async _fetchAuthThumb(url) {
+    if (!url || !url.startsWith("/")) return url;
+    this._thumbCache = this._thumbCache || new Map();
+    if (this._thumbCache.has(url)) return this._thumbCache.get(url);
+    try {
+      const token = this._hass.auth?.data?.access_token;
+      if (!token) return url;
+      const resp = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+      if (!resp.ok) return url;
+      const blobUrl = URL.createObjectURL(await resp.blob());
+      this._thumbCache.set(url, blobUrl);
+      return blobUrl;
+    } catch { return url; }
   }
 
   async _saveImageUrl(task, colIdx, url) {

--- a/custom_components/home_tasks/manifest.json
+++ b/custom_components/home_tasks/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/L3t4l3s/home-tasks/issues",
-  "version": "1.13.1"
+  "version": "1.14.0"
 }

--- a/custom_components/home_tasks/manifest.json
+++ b/custom_components/home_tasks/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Tasks",
   "codeowners": ["@L3t4l3s"],
   "config_flow": true,
-  "dependencies": ["frontend", "http", "todo"],
+  "dependencies": ["ai_task", "frontend", "http", "todo"],
   "documentation": "https://github.com/L3t4l3s/home-tasks",
   "integration_type": "service",
   "iot_class": "local_push",

--- a/custom_components/home_tasks/store.py
+++ b/custom_components/home_tasks/store.py
@@ -396,6 +396,7 @@ class HomeTasksStore:
             task.setdefault("assigned_person", None)
             task.setdefault("tags", [])
             task.setdefault("history", [])
+            task.setdefault("image_url", None)
 
     async def _async_save(self) -> None:
         """Save data to disk."""
@@ -446,6 +447,7 @@ class HomeTasksStore:
             "completed_at": None,
             "assigned_person": None,
             "tags": [],
+            "image_url": None,
             "history": [created_entry],
             "external_id": None,
             "sync_source": None,
@@ -472,7 +474,7 @@ class HomeTasksStore:
         "recurrence_max_count", "recurrence_remaining_count",
         "recurrence_month_pattern", "recurrence_day_of_month",
         "recurrence_nth_week", "recurrence_anniversary",
-        "assigned_person", "tags", "section_id",
+        "assigned_person", "tags", "section_id", "image_url",
     )
 
     async def async_update_task(self, task_id: str, actor: str | None = None, **kwargs) -> dict:

--- a/custom_components/home_tasks/store.py
+++ b/custom_components/home_tasks/store.py
@@ -684,6 +684,42 @@ class HomeTasksStore:
             self.on_task_created(task)
         return task
 
+    async def async_duplicate_task(
+        self,
+        task_id: str,
+        assigned_person: str | None = None,
+        actor: str | None = None,
+    ) -> dict:
+        """Create an independent copy of a task, optionally with a different assignee."""
+        if len(self._data["tasks"]) >= MAX_TASKS_PER_LIST:
+            raise ValueError(f"Maximum number of tasks ({MAX_TASKS_PER_LIST}) reached")
+        source = self.get_task(task_id)
+        max_order = max((t["sort_order"] for t in self._data["tasks"]), default=-1)
+        history_entry: dict = {"ts": datetime.now(timezone.utc).isoformat(), "action": "duplicated_from", "source_id": task_id}
+        if actor:
+            history_entry["by"] = actor
+        new_task = {
+            **source,
+            "id": str(uuid.uuid4()),
+            "sub_items": [{"id": str(uuid.uuid4()), "title": s["title"], "completed": False} for s in source.get("sub_items", [])],
+            "tags": list(source.get("tags", [])),
+            "reminders": list(source.get("reminders", [])),
+            "recurrence_weekdays": list(source.get("recurrence_weekdays", [])),
+            "assigned_person": validate_assigned_person(assigned_person),
+            "completed": False,
+            "completed_at": None,
+            "sort_order": max_order + 1,
+            "history": [history_entry],
+            "external_id": None,
+            "sync_source": None,
+            "recurrence_remaining_count": source.get("recurrence_max_count"),
+        }
+        self._data["tasks"].append(new_task)
+        await self._async_save()
+        if self.on_task_created:
+            self.on_task_created(new_task)
+        return new_task
+
     # --- Sub-task methods ---
 
     async def async_add_sub_task(self, task_id: str, title: str) -> dict:

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -1,13 +1,18 @@
 """WebSocket API for Home Tasks - extended features (sub-tasks, reorder, external)."""
 
+import asyncio
+import json
 import logging
+import os
+import re
 
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, MAX_REORDER_IDS, MAX_RECURRENCE_VALUE, MAX_REMINDER_OFFSET_MINUTES, MAX_REMINDERS_PER_TASK, MAX_SUB_TASKS_PER_TASK, MAX_TAGS_PER_TASK, MAX_TITLE_LENGTH, VALID_RECURRENCE_UNITS
+from .const import DOMAIN, MAX_IMAGE_URL_LENGTH, MAX_REORDER_IDS, MAX_RECURRENCE_VALUE, MAX_REMINDER_OFFSET_MINUTES, MAX_REMINDERS_PER_TASK, MAX_SUB_TASKS_PER_TASK, MAX_TAGS_PER_TASK, MAX_TITLE_LENGTH, VALID_RECURRENCE_UNITS
 from .overlay_store import ExternalTaskOverlayStore, OVERLAY_FIELDS
 from .provider_adapters import ProviderAdapter, GenericAdapter, _get_external_todo_items
 
@@ -63,6 +68,8 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_update_section)
     websocket_api.async_register_command(hass, ws_delete_section)
     websocket_api.async_register_command(hass, ws_reorder_sections)
+    # Image generation
+    websocket_api.async_register_command(hass, ws_generate_task_image)
 
 
 def _get_store(hass, entry_id):
@@ -1360,5 +1367,123 @@ async def ws_reorder_sections(hass, connection, msg):
         store = _get_sections_store(hass, msg)
         await store.async_reorder_sections(msg["section_ids"])
         connection.send_result(msg["id"])
+    except Exception as err:
+        _handle_error(connection, msg["id"], err)
+
+
+# ---------------------------------------------------------------------------
+# Image generation
+# ---------------------------------------------------------------------------
+
+def _get_openai_api_key(hass: HomeAssistant) -> str | None:
+    """Try to obtain an OpenAI API key from an existing openai_conversation config entry."""
+    for entry in hass.config_entries.async_entries("openai_conversation"):
+        key = entry.data.get("api_key") or entry.data.get("openai_api_key")
+        if key:
+            return key
+    return None
+
+
+_SAFE_FILENAME = re.compile(r"[^a-zA-Z0-9_\-]")
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "home_tasks/generate_task_image",
+        vol.Required("entry_id"): _val_id,
+        vol.Required("task_id"): _val_id,
+        # Optional overrides — if not provided, auto-detect from HA config entries
+        vol.Optional("api_key"): vol.All(str, vol.Length(min=1, max=512)),
+        vol.Optional("endpoint"): vol.All(str, vol.Length(min=1, max=512)),
+        vol.Optional("model"): vol.All(str, vol.Length(min=1, max=100)),
+        vol.Optional("size"): vol.In(["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]),
+        vol.Optional("quality"): vol.In(["standard", "hd"]),
+        vol.Optional("prompt_prefix"): vol.All(str, vol.Length(max=200)),
+    }
+)
+@websocket_api.async_response
+async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
+    """Generate an AI image for a task and save it to www/home_tasks_images/."""
+    try:
+        store = _get_store(hass, msg["entry_id"])
+        task = store.get_task(msg["task_id"])
+
+        # --- Resolve API key ---
+        api_key = msg.get("api_key") or _get_openai_api_key(hass)
+        if not api_key:
+            raise ValueError(
+                "No OpenAI API key found. Either configure the openai_conversation "
+                "integration in Home Assistant or provide api_key in the card config."
+            )
+
+        endpoint = msg.get("endpoint", "https://api.openai.com/v1/images/generations")
+        model = msg.get("model", "dall-e-3")
+        size = msg.get("size", "1024x1024")
+        quality = msg.get("quality", "standard")
+        prompt_prefix = msg.get("prompt_prefix", "")
+
+        title = task.get("title", "")
+        prompt = f"{prompt_prefix}{title}" if prompt_prefix else title
+
+        # --- Call image generation API ---
+        session = async_get_clientsession(hass)
+        payload = {
+            "model": model,
+            "prompt": prompt,
+            "n": 1,
+            "size": size,
+            "quality": quality,
+            "response_format": "url",
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with session.post(endpoint, json=payload, headers=headers, timeout=60) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                _LOGGER.error("Image generation API error %s: %s", resp.status, body[:500])
+                try:
+                    import json as _json
+                    err_data = _json.loads(body)
+                    msg_text = err_data.get("error", {}).get("message", body[:200])
+                except Exception:
+                    msg_text = body[:200]
+                raise ValueError(f"Image generation failed: {msg_text}")
+            data = await resp.json()
+
+        image_url_remote = data["data"][0]["url"]
+
+        # --- Download image ---
+        async with session.get(image_url_remote, timeout=60) as img_resp:
+            if img_resp.status != 200:
+                raise ValueError("Failed to download generated image")
+            image_bytes = await img_resp.read()
+
+        # --- Save to www/home_tasks_images/ ---
+        www_dir = hass.config.path("www", "home_tasks_images")
+        os.makedirs(www_dir, exist_ok=True)
+
+        safe_task_id = _SAFE_FILENAME.sub("_", msg["task_id"])
+        filename = f"{safe_task_id}.png"
+        file_path = os.path.join(www_dir, filename)
+
+        def _write(path, data):
+            with open(path, "wb") as fh:
+                fh.write(data)
+
+        await hass.async_add_executor_job(_write, file_path, image_bytes)
+
+        local_url = f"/local/home_tasks_images/{filename}"
+
+        # --- Persist URL on task ---
+        updated_task = await store.async_update_task(
+            msg["task_id"],
+            image_url=local_url,
+        )
+
+        connection.send_result(msg["id"], {"task": updated_task})
+
     except Exception as err:
         _handle_error(connection, msg["id"], err)

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -1371,6 +1371,70 @@ async def ws_reorder_sections(hass, connection, msg):
 # Image generation
 # ---------------------------------------------------------------------------
 
+async def _save_image_to_public_media(hass, connection, image_url: str, filename: str) -> str:
+    """Download an auth-required HA image URL and save it to the public media dir.
+
+    Returns a /media/local/home_tasks/<filename> URL that is accessible
+    without authentication, so the Lovelace card can display it in <img src>.
+    Falls back to the original URL on any error.
+    """
+    import os
+    from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+    if not image_url:
+        return image_url
+
+    # Already public — nothing to do
+    if image_url.startswith(("/media/", "/local/", "http://", "https://")):
+        return image_url
+
+    try:
+        media_dir = hass.config.path("media", "home_tasks")
+        await hass.async_add_executor_job(os.makedirs, media_dir, 0o755, True)
+        dest = os.path.join(media_dir, filename)
+
+        # Build an access token for the current user so we can hit HA's own API
+        refresh_token = await hass.auth.async_get_refresh_token(connection.refresh_token_id)
+        if refresh_token is None:
+            _LOGGER.warning("No refresh token available; skipping image re-save")
+            return image_url
+        access_token = hass.auth.async_create_access_token(refresh_token)
+
+        # Determine HA's local HTTP URL (prefer http loopback; handle SSL too)
+        try:
+            port = hass.http.server_port
+            use_ssl = bool(getattr(hass.http, "ssl_certificate", None))
+        except AttributeError:
+            port = 8123
+            use_ssl = False
+
+        scheme = "https" if use_ssl else "http"
+        internal_url = f"{scheme}://127.0.0.1:{port}{image_url}"
+
+        session = async_get_clientsession(hass, verify_ssl=False)
+        async with session.get(
+            internal_url,
+            headers={"Authorization": f"Bearer {access_token.token}"},
+        ) as resp:
+            if resp.status != 200:
+                _LOGGER.warning(
+                    "Image download returned HTTP %s for %s — keeping original URL",
+                    resp.status, image_url,
+                )
+                return image_url
+            image_data = await resp.read()
+
+        def _write() -> None:
+            with open(dest, "wb") as fh:
+                fh.write(image_data)
+
+        await hass.async_add_executor_job(_write)
+        return f"/media/local/home_tasks/{filename}"
+
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("Failed to save image to public media dir: %s", exc)
+        return image_url
+
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "home_tasks/generate_task_image",
@@ -1459,9 +1523,22 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
         except Exception as service_err:
             raise ValueError(f"Image generation failed: {service_err}") from service_err
 
-        image_url = (service_result or {}).get("url") or (service_result or {}).get("media_source_id")
+        _LOGGER.debug("ai_task.generate_image result: %s", service_result)
+        result_dict = service_result or {}
+        image_url = (
+            result_dict.get("url")
+            or result_dict.get("media_source_id")
+            or (result_dict.get("image") or {}).get("url")
+        )
         if not image_url:
-            raise ValueError("ai_task.generate_image returned no image URL")
+            raise ValueError(
+                f"ai_task.generate_image returned no image URL. Full result: {result_dict}"
+            )
+
+        # Convert auth-required internal URLs to public /media/local/ URLs so
+        # the Lovelace card can display them without auth headers.
+        image_filename = f"{title_hash}.png"
+        image_url = await _save_image_to_public_media(hass, connection, image_url, image_filename)
 
         # ------------------------------------------------------------------
         # 3. Propagate URL to every task with the same title across all lists.

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -1377,6 +1377,7 @@ async def ws_reorder_sections(hass, connection, msg):
         vol.Required("entry_id"): _val_id,
         vol.Required("task_id"): _val_id,
         vol.Optional("prompt_prefix"): vol.All(str, vol.Length(max=200)),
+        vol.Optional("entity_id"): _val_entity_id,
         vol.Optional("force"): bool,
     }
 )
@@ -1438,6 +1439,7 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
                 {
                     "task_name": f"home_tasks_{title_hash}",
                     "instructions": prompt,
+                    **({"entity_id": msg["entity_id"]} if msg.get("entity_id") else {}),
                 },
                 blocking=True,
                 return_response=True,

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -37,6 +37,7 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_add_task)
     websocket_api.async_register_command(hass, ws_update_task)
     websocket_api.async_register_command(hass, ws_delete_task)
+    websocket_api.async_register_command(hass, ws_duplicate_task)
     websocket_api.async_register_command(hass, ws_reorder_tasks)
     websocket_api.async_register_command(hass, ws_add_sub_task)
     websocket_api.async_register_command(hass, ws_update_sub_task)
@@ -236,6 +237,30 @@ async def ws_delete_task(hass, connection, msg):
         store = _get_store(hass, msg["list_id"])
         await store.async_delete_task(msg["task_id"])
         connection.send_result(msg["id"])
+    except Exception as err:
+        _handle_error(connection, msg["id"], err)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "home_tasks/duplicate_task",
+        vol.Required("list_id"): _val_id,
+        vol.Required("task_id"): _val_id,
+        vol.Optional("assigned_person"): vol.Any(str, None),
+    }
+)
+@websocket_api.async_response
+async def ws_duplicate_task(hass, connection, msg):
+    """Duplicate a task, optionally reassigning it to another person."""
+    try:
+        store = _get_store(hass, msg["list_id"])
+        actor = connection.user.name if connection.user else None
+        task = await store.async_duplicate_task(
+            msg["task_id"],
+            assigned_person=msg.get("assigned_person"),
+            actor=actor,
+        )
+        connection.send_result(msg["id"], task)
     except Exception as err:
         _handle_error(connection, msg["id"], err)
 

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -1,16 +1,11 @@
 """WebSocket API for Home Tasks - extended features (sub-tasks, reorder, external)."""
 
-import asyncio
-import json
 import logging
-import os
-import re
 
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN, MAX_IMAGE_URL_LENGTH, MAX_REORDER_IDS, MAX_RECURRENCE_VALUE, MAX_REMINDER_OFFSET_MINUTES, MAX_REMINDERS_PER_TASK, MAX_SUB_TASKS_PER_TASK, MAX_TAGS_PER_TASK, MAX_TITLE_LENGTH, VALID_RECURRENCE_UNITS
 from .overlay_store import ExternalTaskOverlayStore, OVERLAY_FIELDS
@@ -1376,42 +1371,26 @@ async def ws_reorder_sections(hass, connection, msg):
 # Image generation
 # ---------------------------------------------------------------------------
 
-def _get_openai_api_key(hass: HomeAssistant) -> str | None:
-    """Try to obtain an OpenAI API key from an existing openai_conversation config entry."""
-    for entry in hass.config_entries.async_entries("openai_conversation"):
-        key = entry.data.get("api_key") or entry.data.get("openai_api_key")
-        if key:
-            return key
-    return None
-
-
-_SAFE_FILENAME = re.compile(r"[^a-zA-Z0-9_\-]")
-
-
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "home_tasks/generate_task_image",
         vol.Required("entry_id"): _val_id,
         vol.Required("task_id"): _val_id,
-        # Optional overrides — if not provided, auto-detect from HA config entries
-        vol.Optional("api_key"): vol.All(str, vol.Length(min=1, max=512)),
-        vol.Optional("endpoint"): vol.All(str, vol.Length(min=1, max=512)),
-        vol.Optional("model"): vol.All(str, vol.Length(min=1, max=100)),
-        vol.Optional("size"): vol.In(["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]),
-        vol.Optional("quality"): vol.In(["standard", "hd", "low", "medium", "high"]),
         vol.Optional("prompt_prefix"): vol.All(str, vol.Length(max=200)),
         vol.Optional("force"): bool,
     }
 )
 @websocket_api.async_response
 async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
-    """Generate an AI image for a task and save it to www/home_tasks_images/.
+    """Generate an AI image for a task via HA's ai_task integration.
 
-    Tasks with the same title share a single image:
-    - Before calling the API, all stores are searched for an existing image for
-      the same normalised title.  If one is found it is reused immediately.
-    - After a new image is generated the URL is propagated to every task across
-      all stores that carries the same normalised title.
+    Delegates to ai_task.generate_image — works with any configured AI
+    provider (OpenAI, Gemini, Anthropic, local models).  The generated image
+    lands in HA's Media Source; no API key handling or file I/O needed here.
+
+    Tasks with the same normalised title share a single image: before calling
+    the service the stores are checked for an existing URL.  After generation
+    the URL is propagated to every task with the same title across all lists.
     """
     import hashlib
 
@@ -1420,157 +1399,71 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
         task = store.get_task(msg["task_id"])
 
         title = task.get("title", "")
-        title_key = title.strip().lower()   # normalised key for matching
-
-        # Stable, title-based filename so all tasks with the same title
-        # always point at the same file on disk.
-        title_hash = hashlib.md5(title_key.encode()).hexdigest()[:16]
-        filename = f"task_{title_hash}.png"
-        local_url = f"/local/home_tasks_images/{filename}"
+        title_key = title.strip().lower()
+        title_hash = hashlib.md5(title_key.encode(), usedforsecurity=False).hexdigest()[:16]
 
         all_stores = hass.data.get(DOMAIN, {})
 
         # ------------------------------------------------------------------
-        # 1. Reuse: if any task with the same title already has this image
-        #    (or the file already exists on disk) skip the API call entirely.
-        #    Skipped when force=True (user clicked "Bild neu generieren").
+        # 1. Reuse: if any task with the same title already has an image URL,
+        #    skip the service call (bypass with force=True).
         # ------------------------------------------------------------------
-        force = msg.get("force", False)
-        www_dir = hass.config.path("www", "home_tasks_images")
-        file_path = os.path.join(www_dir, filename)
-
-        if not force:
-            file_exists = await hass.async_add_executor_job(os.path.exists, file_path)
-
+        if not msg.get("force", False):
             existing_url: str | None = None
-            if file_exists:
-                existing_url = local_url
-            else:
-                for s in all_stores.values():
-                    if not hasattr(s, "tasks"):
-                        continue
-                    for t in s.tasks:
-                        if t.get("title", "").strip().lower() == title_key and t.get("image_url"):
-                            existing_url = t["image_url"]
-                            break
-                    if existing_url:
+            for s in all_stores.values():
+                if not hasattr(s, "tasks"):
+                    continue
+                for t in s.tasks:
+                    if t.get("title", "").strip().lower() == title_key and t.get("image_url"):
+                        existing_url = t["image_url"]
                         break
+                if existing_url:
+                    break
 
             if existing_url:
-                # Just stamp the URL on the requesting task and return.
-                updated_task = await store.async_update_task(
-                    msg["task_id"],
-                    image_url=existing_url,
-                )
+                updated_task = await store.async_update_task(msg["task_id"], image_url=existing_url)
                 connection.send_result(msg["id"], {"task": updated_task})
                 return
 
         # ------------------------------------------------------------------
-        # 2. Generate: call the image API.
+        # 2. Generate via ai_task.generate_image (provider-agnostic).
         # ------------------------------------------------------------------
-        api_key = msg.get("api_key") or _get_openai_api_key(hass)
-        if not api_key:
-            raise ValueError(
-                "No OpenAI API key found. Either configure the openai_conversation "
-                "integration in Home Assistant or provide api_key in the card config."
-            )
-
-        endpoint = msg.get("endpoint", "https://api.openai.com/v1/images/generations")
-        model = msg.get("model", "dall-e-3")
-        size = msg.get("size", "1024x1024")
-        quality = msg.get("quality", "standard")
         prompt_prefix = msg.get("prompt_prefix", "")
-
         prompt = f"{prompt_prefix}{title}" if prompt_prefix else title
 
-        # Never send response_format — older models return a URL, newer ones
-        # (gpt-image-1) return b64_json.  We handle both below.
-        # gpt-image-1 quality values: low / medium / high (not standard/hd).
-        is_gpt_image = model.startswith("gpt-image")
-        session = async_get_clientsession(hass)
-        payload: dict = {
-            "model": model,
-            "prompt": prompt,
-            "n": 1,
-            "size": size,
-        }
-        if not is_gpt_image or quality not in ("standard", "hd"):
-            payload["quality"] = quality
+        try:
+            service_result = await hass.services.async_call(
+                "ai_task",
+                "generate_image",
+                {
+                    "task_name": f"home_tasks_{title_hash}",
+                    "prompt": prompt,
+                },
+                blocking=True,
+                return_response=True,
+            )
+        except Exception as service_err:
+            raise ValueError(f"Image generation failed: {service_err}") from service_err
 
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        }
-
-        async with session.post(endpoint, json=payload, headers=headers, timeout=120) as resp:
-            if resp.status != 200:
-                body = await resp.text()
-                _LOGGER.error("Image generation API error %s: %s", resp.status, body[:500])
-                try:
-                    import json as _json
-                    err_data = _json.loads(body)
-                    msg_text = err_data.get("error", {}).get("message", body[:200])
-                except Exception:
-                    msg_text = body[:200]
-                raise ValueError(f"Image generation failed: {msg_text}")
-            data = await resp.json()
-
-        api_entry = data["data"][0]
-
-        # Obtain raw image bytes (b64 or remote URL)
-        if "b64_json" in api_entry:
-            import base64 as _b64
-            image_bytes = _b64.b64decode(api_entry["b64_json"])
-        else:
-            image_url_remote = api_entry["url"]
-            async with session.get(image_url_remote, timeout=60) as img_resp:
-                if img_resp.status != 200:
-                    raise ValueError("Failed to download generated image")
-                image_bytes = await img_resp.read()
+        image_url = (service_result or {}).get("url") or (service_result or {}).get("media_source_id")
+        if not image_url:
+            raise ValueError("ai_task.generate_image returned no image URL")
 
         # ------------------------------------------------------------------
-        # 3. Save full image + generate thumbnail
-        # ------------------------------------------------------------------
-        os.makedirs(www_dir, exist_ok=True)
-
-        thumb_filename = filename.replace(".png", "_thumb.jpg")
-        thumb_path = os.path.join(www_dir, thumb_filename)
-
-        def _write_and_thumb(path, thumb, data):
-            # Write full image
-            with open(path, "wb") as fh:
-                fh.write(data)
-            # Generate 300×300 JPEG thumbnail with Pillow (optional dep)
-            try:
-                from PIL import Image
-                import io as _io
-                with Image.open(_io.BytesIO(data)) as img:
-                    img = img.convert("RGB")
-                    img.thumbnail((300, 300), Image.LANCZOS)
-                    img.save(thumb, "JPEG", quality=82, optimize=True)
-            except Exception:
-                # Pillow not available — copy full image as thumbnail fallback
-                with open(thumb, "wb") as fh:
-                    fh.write(data)
-
-        await hass.async_add_executor_job(_write_and_thumb, file_path, thumb_path, image_bytes)
-
-        # ------------------------------------------------------------------
-        # 4. Propagate: stamp every task with the same title across all lists.
+        # 3. Propagate URL to every task with the same title across all lists.
         # ------------------------------------------------------------------
         updated_task = None
         for s in all_stores.values():
             if not hasattr(s, "tasks"):
                 continue
             for t in s.tasks:
-                if t.get("title", "").strip().lower() == title_key and t.get("image_url") != local_url:
-                    result = await s.async_update_task(t["id"], image_url=local_url)
+                if t.get("title", "").strip().lower() == title_key and t.get("image_url") != image_url:
+                    stamped = await s.async_update_task(t["id"], image_url=image_url)
                     if t["id"] == msg["task_id"]:
-                        updated_task = result
+                        updated_task = stamped
 
-        # Fallback: if the requesting task wasn't caught above (shouldn't happen)
         if updated_task is None:
-            updated_task = await store.async_update_task(msg["task_id"], image_url=local_url)
+            updated_task = await store.async_update_task(msg["task_id"], image_url=image_url)
 
         connection.send_result(msg["id"], {"task": updated_task})
 

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -1432,6 +1432,18 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
         prompt_prefix = msg.get("prompt_prefix", "")
         prompt = f"{prompt_prefix}{title}" if prompt_prefix else title
 
+        entity_id = msg.get("entity_id")
+        if not entity_id:
+            from homeassistant.helpers import entity_registry as er
+            ent_reg = er.async_get(hass)
+            ai_entities = [
+                e.entity_id for e in ent_reg.entities.values()
+                if e.domain == "ai_task" and not e.disabled_by
+            ]
+            if not ai_entities:
+                raise ValueError("No ai_task entity found — configure one in the card editor")
+            entity_id = ai_entities[0]
+
         try:
             service_result = await hass.services.async_call(
                 "ai_task",
@@ -1439,7 +1451,7 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
                 {
                     "task_name": f"home_tasks_{title_hash}",
                     "instructions": prompt,
-                    **({"entity_id": msg["entity_id"]} if msg.get("entity_id") else {}),
+                    "entity_id": entity_id,
                 },
                 blocking=True,
                 return_response=True,

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -9,6 +9,7 @@ import re
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -68,8 +69,9 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_update_section)
     websocket_api.async_register_command(hass, ws_delete_section)
     websocket_api.async_register_command(hass, ws_reorder_sections)
-    # Image generation
+    # Image generation + upload
     websocket_api.async_register_command(hass, ws_generate_task_image)
+    hass.http.register_view(TaskImageUploadView(hass))
 
 
 def _get_store(hass, entry_id):
@@ -200,6 +202,7 @@ async def ws_add_task(hass, connection, msg):
         vol.Optional("assigned_person"): vol.Any(str, None),
         vol.Optional("tags"): vol.All(list, vol.Length(max=MAX_TAGS_PER_TASK)),
         vol.Optional("section_id"): vol.Any(_val_id, None),
+        vol.Optional("image_url"): vol.Any(str, None),
     }
 )
 @websocket_api.async_response
@@ -216,7 +219,7 @@ async def ws_update_task(hass, connection, msg):
             "recurrence_end_type", "recurrence_end_date", "recurrence_max_count",
             "recurrence_remaining_count", "recurrence_month_pattern",
             "recurrence_day_of_month", "recurrence_nth_week", "recurrence_anniversary",
-            "assigned_person", "tags", "section_id",
+            "assigned_person", "tags", "section_id", "image_url",
         ):
             if key in msg:
                 kwargs[key] = msg[key]
@@ -1387,6 +1390,92 @@ def _get_openai_api_key(hass: HomeAssistant) -> str | None:
 _SAFE_FILENAME = re.compile(r"[^a-zA-Z0-9_\-]")
 
 
+class TaskImageUploadView(HomeAssistantView):
+    """HTTP endpoint for uploading a local image file to a task.
+
+    POST /api/home_tasks/upload_image
+    Multipart form fields: entry_id, task_id, image (file)
+    """
+
+    url = "/api/home_tasks/upload_image"
+    name = "api:home_tasks:upload_image"
+    requires_auth = True
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+
+    async def post(self, request):
+        import hashlib
+
+        try:
+            data = await request.post()
+            entry_id = data.get("entry_id")
+            task_id = data.get("task_id")
+            image_field = data.get("image")
+
+            if not entry_id or not task_id or not image_field:
+                return self.json_message("Missing required fields: entry_id, task_id, image", status_code=400)
+
+            store = _get_store(self.hass, entry_id)
+            task = store.get_task(task_id)
+
+            image_bytes = image_field.file.read()
+            if not image_bytes:
+                return self.json_message("Empty image file", status_code=400)
+
+            title = task.get("title", "")
+            title_key = title.strip().lower()
+            title_hash = hashlib.md5(title_key.encode()).hexdigest()[:16]
+            filename = f"task_{title_hash}.png"
+            local_url = f"/local/home_tasks_images/{filename}"
+
+            www_dir = self.hass.config.path("www", "home_tasks_images")
+            file_path = os.path.join(www_dir, filename)
+            thumb_filename = filename.replace(".png", "_thumb.jpg")
+            thumb_path = os.path.join(www_dir, thumb_filename)
+
+            def _write_and_thumb(path, thumb, data):
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "wb") as fh:
+                    fh.write(data)
+                try:
+                    from PIL import Image
+                    import io as _io
+                    with Image.open(_io.BytesIO(data)) as img:
+                        img = img.convert("RGB")
+                        img.thumbnail((300, 300), Image.LANCZOS)
+                        img.save(thumb, "JPEG", quality=82, optimize=True)
+                except Exception:
+                    with open(thumb, "wb") as fh:
+                        fh.write(data)
+
+            await self.hass.async_add_executor_job(_write_and_thumb, file_path, thumb_path, image_bytes)
+
+            # Update requesting task
+            updated_task = await store.async_update_task(task_id, image_url=local_url)
+
+            # Propagate to other tasks with the same title
+            all_stores = self.hass.data.get(DOMAIN, {})
+            for s in all_stores.values():
+                if not hasattr(s, "tasks"):
+                    continue
+                for t in s.tasks:
+                    if (
+                        t.get("title", "").strip().lower() == title_key
+                        and t.get("image_url") != local_url
+                        and t["id"] != task_id
+                    ):
+                        await s.async_update_task(t["id"], image_url=local_url)
+
+            return self.json({"task": updated_task, "image_url": local_url})
+
+        except KeyError:
+            return self.json_message("List or task not found", status_code=404)
+        except Exception as err:
+            _LOGGER.error("Image upload error: %s", err)
+            return self.json_message(str(err), status_code=500)
+
+
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "home_tasks/generate_task_image",
@@ -1397,18 +1486,76 @@ _SAFE_FILENAME = re.compile(r"[^a-zA-Z0-9_\-]")
         vol.Optional("endpoint"): vol.All(str, vol.Length(min=1, max=512)),
         vol.Optional("model"): vol.All(str, vol.Length(min=1, max=100)),
         vol.Optional("size"): vol.In(["256x256", "512x512", "1024x1024", "1792x1024", "1024x1792"]),
-        vol.Optional("quality"): vol.In(["standard", "hd"]),
+        vol.Optional("quality"): vol.In(["standard", "hd", "low", "medium", "high"]),
         vol.Optional("prompt_prefix"): vol.All(str, vol.Length(max=200)),
+        vol.Optional("force"): bool,
     }
 )
 @websocket_api.async_response
 async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
-    """Generate an AI image for a task and save it to www/home_tasks_images/."""
+    """Generate an AI image for a task and save it to www/home_tasks_images/.
+
+    Tasks with the same title share a single image:
+    - Before calling the API, all stores are searched for an existing image for
+      the same normalised title.  If one is found it is reused immediately.
+    - After a new image is generated the URL is propagated to every task across
+      all stores that carries the same normalised title.
+    """
+    import hashlib
+
     try:
         store = _get_store(hass, msg["entry_id"])
         task = store.get_task(msg["task_id"])
 
-        # --- Resolve API key ---
+        title = task.get("title", "")
+        title_key = title.strip().lower()   # normalised key for matching
+
+        # Stable, title-based filename so all tasks with the same title
+        # always point at the same file on disk.
+        title_hash = hashlib.md5(title_key.encode()).hexdigest()[:16]
+        filename = f"task_{title_hash}.png"
+        local_url = f"/local/home_tasks_images/{filename}"
+
+        all_stores = hass.data.get(DOMAIN, {})
+
+        # ------------------------------------------------------------------
+        # 1. Reuse: if any task with the same title already has this image
+        #    (or the file already exists on disk) skip the API call entirely.
+        #    Skipped when force=True (user clicked "Bild neu generieren").
+        # ------------------------------------------------------------------
+        force = msg.get("force", False)
+        www_dir = hass.config.path("www", "home_tasks_images")
+        file_path = os.path.join(www_dir, filename)
+
+        if not force:
+            file_exists = await hass.async_add_executor_job(os.path.exists, file_path)
+
+            existing_url: str | None = None
+            if file_exists:
+                existing_url = local_url
+            else:
+                for s in all_stores.values():
+                    if not hasattr(s, "tasks"):
+                        continue
+                    for t in s.tasks:
+                        if t.get("title", "").strip().lower() == title_key and t.get("image_url"):
+                            existing_url = t["image_url"]
+                            break
+                    if existing_url:
+                        break
+
+            if existing_url:
+                # Just stamp the URL on the requesting task and return.
+                updated_task = await store.async_update_task(
+                    msg["task_id"],
+                    image_url=existing_url,
+                )
+                connection.send_result(msg["id"], {"task": updated_task})
+                return
+
+        # ------------------------------------------------------------------
+        # 2. Generate: call the image API.
+        # ------------------------------------------------------------------
         api_key = msg.get("api_key") or _get_openai_api_key(hass)
         if not api_key:
             raise ValueError(
@@ -1422,25 +1569,28 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
         quality = msg.get("quality", "standard")
         prompt_prefix = msg.get("prompt_prefix", "")
 
-        title = task.get("title", "")
         prompt = f"{prompt_prefix}{title}" if prompt_prefix else title
 
-        # --- Call image generation API ---
+        # Never send response_format — older models return a URL, newer ones
+        # (gpt-image-1) return b64_json.  We handle both below.
+        # gpt-image-1 quality values: low / medium / high (not standard/hd).
+        is_gpt_image = model.startswith("gpt-image")
         session = async_get_clientsession(hass)
-        payload = {
+        payload: dict = {
             "model": model,
             "prompt": prompt,
             "n": 1,
             "size": size,
-            "quality": quality,
-            "response_format": "url",
         }
+        if not is_gpt_image or quality not in ("standard", "hd"):
+            payload["quality"] = quality
+
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
 
-        async with session.post(endpoint, json=payload, headers=headers, timeout=60) as resp:
+        async with session.post(endpoint, json=payload, headers=headers, timeout=120) as resp:
             if resp.status != 200:
                 body = await resp.text()
                 _LOGGER.error("Image generation API error %s: %s", resp.status, body[:500])
@@ -1453,35 +1603,62 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
                 raise ValueError(f"Image generation failed: {msg_text}")
             data = await resp.json()
 
-        image_url_remote = data["data"][0]["url"]
+        api_entry = data["data"][0]
 
-        # --- Download image ---
-        async with session.get(image_url_remote, timeout=60) as img_resp:
-            if img_resp.status != 200:
-                raise ValueError("Failed to download generated image")
-            image_bytes = await img_resp.read()
+        # Obtain raw image bytes (b64 or remote URL)
+        if "b64_json" in api_entry:
+            import base64 as _b64
+            image_bytes = _b64.b64decode(api_entry["b64_json"])
+        else:
+            image_url_remote = api_entry["url"]
+            async with session.get(image_url_remote, timeout=60) as img_resp:
+                if img_resp.status != 200:
+                    raise ValueError("Failed to download generated image")
+                image_bytes = await img_resp.read()
 
-        # --- Save to www/home_tasks_images/ ---
-        www_dir = hass.config.path("www", "home_tasks_images")
+        # ------------------------------------------------------------------
+        # 3. Save full image + generate thumbnail
+        # ------------------------------------------------------------------
         os.makedirs(www_dir, exist_ok=True)
 
-        safe_task_id = _SAFE_FILENAME.sub("_", msg["task_id"])
-        filename = f"{safe_task_id}.png"
-        file_path = os.path.join(www_dir, filename)
+        thumb_filename = filename.replace(".png", "_thumb.jpg")
+        thumb_path = os.path.join(www_dir, thumb_filename)
 
-        def _write(path, data):
+        def _write_and_thumb(path, thumb, data):
+            # Write full image
             with open(path, "wb") as fh:
                 fh.write(data)
+            # Generate 300×300 JPEG thumbnail with Pillow (optional dep)
+            try:
+                from PIL import Image
+                import io as _io
+                with Image.open(_io.BytesIO(data)) as img:
+                    img = img.convert("RGB")
+                    img.thumbnail((300, 300), Image.LANCZOS)
+                    img.save(thumb, "JPEG", quality=82, optimize=True)
+            except Exception:
+                # Pillow not available — copy full image as thumbnail fallback
+                with open(thumb, "wb") as fh:
+                    fh.write(data)
 
-        await hass.async_add_executor_job(_write, file_path, image_bytes)
+        await hass.async_add_executor_job(_write_and_thumb, file_path, thumb_path, image_bytes)
 
-        local_url = f"/local/home_tasks_images/{filename}"
+        # ------------------------------------------------------------------
+        # 4. Propagate: stamp every task with the same title across all lists.
+        # ------------------------------------------------------------------
+        updated_task = None
+        for s in all_stores.values():
+            if not hasattr(s, "tasks"):
+                continue
+            for t in s.tasks:
+                if t.get("title", "").strip().lower() == title_key and t.get("image_url") != local_url:
+                    result = await s.async_update_task(t["id"], image_url=local_url)
+                    if t["id"] == msg["task_id"]:
+                        updated_task = result
 
-        # --- Persist URL on task ---
-        updated_task = await store.async_update_task(
-            msg["task_id"],
-            image_url=local_url,
-        )
+        # Fallback: if the requesting task wasn't caught above (shouldn't happen)
+        if updated_task is None:
+            updated_task = await store.async_update_task(msg["task_id"], image_url=local_url)
 
         connection.send_result(msg["id"], {"task": updated_task})
 

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -9,7 +9,6 @@ import re
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
-from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -69,9 +68,8 @@ def async_register_websocket_commands(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, ws_update_section)
     websocket_api.async_register_command(hass, ws_delete_section)
     websocket_api.async_register_command(hass, ws_reorder_sections)
-    # Image generation + upload
+    # Image generation
     websocket_api.async_register_command(hass, ws_generate_task_image)
-    hass.http.register_view(TaskImageUploadView(hass))
 
 
 def _get_store(hass, entry_id):
@@ -1388,92 +1386,6 @@ def _get_openai_api_key(hass: HomeAssistant) -> str | None:
 
 
 _SAFE_FILENAME = re.compile(r"[^a-zA-Z0-9_\-]")
-
-
-class TaskImageUploadView(HomeAssistantView):
-    """HTTP endpoint for uploading a local image file to a task.
-
-    POST /api/home_tasks/upload_image
-    Multipart form fields: entry_id, task_id, image (file)
-    """
-
-    url = "/api/home_tasks/upload_image"
-    name = "api:home_tasks:upload_image"
-    requires_auth = True
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        self.hass = hass
-
-    async def post(self, request):
-        import hashlib
-
-        try:
-            data = await request.post()
-            entry_id = data.get("entry_id")
-            task_id = data.get("task_id")
-            image_field = data.get("image")
-
-            if not entry_id or not task_id or not image_field:
-                return self.json_message("Missing required fields: entry_id, task_id, image", status_code=400)
-
-            store = _get_store(self.hass, entry_id)
-            task = store.get_task(task_id)
-
-            image_bytes = image_field.file.read()
-            if not image_bytes:
-                return self.json_message("Empty image file", status_code=400)
-
-            title = task.get("title", "")
-            title_key = title.strip().lower()
-            title_hash = hashlib.md5(title_key.encode()).hexdigest()[:16]
-            filename = f"task_{title_hash}.png"
-            local_url = f"/local/home_tasks_images/{filename}"
-
-            www_dir = self.hass.config.path("www", "home_tasks_images")
-            file_path = os.path.join(www_dir, filename)
-            thumb_filename = filename.replace(".png", "_thumb.jpg")
-            thumb_path = os.path.join(www_dir, thumb_filename)
-
-            def _write_and_thumb(path, thumb, data):
-                os.makedirs(os.path.dirname(path), exist_ok=True)
-                with open(path, "wb") as fh:
-                    fh.write(data)
-                try:
-                    from PIL import Image
-                    import io as _io
-                    with Image.open(_io.BytesIO(data)) as img:
-                        img = img.convert("RGB")
-                        img.thumbnail((300, 300), Image.LANCZOS)
-                        img.save(thumb, "JPEG", quality=82, optimize=True)
-                except Exception:
-                    with open(thumb, "wb") as fh:
-                        fh.write(data)
-
-            await self.hass.async_add_executor_job(_write_and_thumb, file_path, thumb_path, image_bytes)
-
-            # Update requesting task
-            updated_task = await store.async_update_task(task_id, image_url=local_url)
-
-            # Propagate to other tasks with the same title
-            all_stores = self.hass.data.get(DOMAIN, {})
-            for s in all_stores.values():
-                if not hasattr(s, "tasks"):
-                    continue
-                for t in s.tasks:
-                    if (
-                        t.get("title", "").strip().lower() == title_key
-                        and t.get("image_url") != local_url
-                        and t["id"] != task_id
-                    ):
-                        await s.async_update_task(t["id"], image_url=local_url)
-
-            return self.json({"task": updated_task, "image_url": local_url})
-
-        except KeyError:
-            return self.json_message("List or task not found", status_code=404)
-        except Exception as err:
-            _LOGGER.error("Image upload error: %s", err)
-            return self.json_message(str(err), status_code=500)
 
 
 @websocket_api.websocket_command(

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -1437,7 +1437,7 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
                 "generate_image",
                 {
                     "task_name": f"home_tasks_{title_hash}",
-                    "prompt": prompt,
+                    "instructions": prompt,
                 },
                 blocking=True,
                 return_response=True,

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -842,6 +842,50 @@ async def test_new_task_has_new_recurrence_fields(hass: HomeAssistant, store) ->
     assert task["recurrence_anniversary"] is None
 
 
+async def test_new_task_has_image_url_field(hass: HomeAssistant, store) -> None:
+    """A freshly created task has image_url defaulted to None."""
+    task = await store.async_add_task("Task with image field")
+    assert "image_url" in task
+    assert task["image_url"] is None
+
+
+async def test_image_url_is_updatable(hass: HomeAssistant, store) -> None:
+    """image_url can be updated on an existing task."""
+    task = await store.async_add_task("Task for image")
+    updated = await store.async_update_task(task["id"], image_url="/local/home_tasks_images/abc.png")
+    assert updated["image_url"] == "/local/home_tasks_images/abc.png"
+
+    # Can also clear it
+    cleared = await store.async_update_task(task["id"], image_url=None)
+    assert cleared["image_url"] is None
+
+
+async def test_image_url_migration(hass: HomeAssistant, tmp_path) -> None:
+    """Tasks loaded from storage without image_url get it backfilled to None."""
+    from custom_components.home_tasks.store import HomeTasksStore
+
+    s = HomeTasksStore(hass, "test_img_migration")
+    s._data = {
+        "tasks": [
+            {
+                "id": "t-img",
+                "title": "Old task",
+                "completed": False,
+                "sort_order": 0,
+                "sub_items": [],
+                "recurrence_enabled": False,
+                "recurrence_type": "interval",
+                "external_id": None,
+                "sync_source": None,
+            }
+        ]
+    }
+    s._backfill_recurrence_fields()
+    s._migrate_v1_to_v2()
+    t = s._data["tasks"][0]
+    assert t.get("image_url") is None
+
+
 async def test_legacy_weekdays_mode_normalised_on_load(hass: HomeAssistant, tmp_path) -> None:
     """A v1 task with recurrence_type='weekdays' is migrated to interval+weeks."""
     from custom_components.home_tasks.store import HomeTasksStore


### PR DESCRIPTION
## Summary

- Adds **"Assign to another person"** button in the task detail actions section (native lists only)
- Clicking reveals an inline person picker (`person.*` entities); selecting a person creates a fully independent copy of the task with that assignee
- Each copy has its own completion state, history, and recurrence tracking — nothing is shared with the original
- New `home_tasks/duplicate_task` WebSocket endpoint and `async_duplicate_task` store method

## Stack

> ⚠️ Depends on **#16** (`feat/task-images`) — merge that first.

## Changes

**`store.py`** — `async_duplicate_task`: copies all task fields (title, notes, due date, priority, tags, recurrence, image, section), generates new UUIDs for task and sub-items, resets `completed`/`completed_at`/`history`, sets the new `assigned_person`.

**`websocket_api.py`** — `home_tasks/duplicate_task` command (`list_id`, `task_id`, optional `assigned_person`). Native lists only.

**`home-tasks-card.js`** — "Assign to another person" button in `_buildActionsSection`, inline `<select>` person picker on click, `_duplicateAndAssign()` async method, CSS for button and select. Translations in all 13 supported languages.

## Test plan

- [ ] Open a task detail → "Assign to another person" button visible (native list only, not on CalDAV/Todoist columns)
- [ ] Select a person → duplicate appears at the bottom of the list with that assignee
- [ ] Original task unchanged (same assignee, same completion state)
- [ ] Completing the copy does not affect the original
- [ ] Sub-tasks, tags, due date, and recurrence all copied correctly
- [ ] Button absent on external columns
- [ ] `MAX_TASKS_PER_LIST` limit → error shown if list is full

🤖 Generated with [Claude Code](https://claude.ai/claude-code)