### PR TITLE
fix: stdlib calendar module shadowed by the calendar platform module

### DIFF
--- a/custom_components/home_tasks/__init__.py
+++ b/custom_components/home_tasks/__init__.py
@@ -1,6 +1,6 @@
 """The Home Tasks integration."""
 
-import calendar
+from calendar import monthrange
 import logging
 from datetime import date, datetime, timedelta, timezone
 
@@ -414,7 +414,7 @@ def _resolve_dom(year: int, month: int, dom) -> int:
 
     Accepts an int 1–31 (clamped to the month's last day) or the literal "last".
     """
-    last = calendar.monthrange(year, month)[1]
+    last = monthrange(year, month)[1]
     if dom == "last":
         return last
     return min(int(dom), last)
@@ -423,7 +423,7 @@ def _resolve_dom(year: int, month: int, dom) -> int:
 def _resolve_nth_weekday(year: int, month: int, nth, weekday: int) -> date | None:
     """Return the date of the nth (1–4) or last *weekday* in (year, month)."""
     matching_days = [
-        day for day in range(1, calendar.monthrange(year, month)[1] + 1)
+        day for day in range(1, monthrange(year, month)[1] + 1)
         if date(year, month, day).weekday() == weekday
     ]
     if not matching_days:
@@ -550,7 +550,7 @@ def _next_monthly_target(task: dict, local_completed: datetime, value: int) -> d
             year, month = _add_months(local_completed.year, local_completed.month, value)
             return local_completed.replace(
                 year=year, month=month,
-                day=min(local_completed.day, calendar.monthrange(year, month)[1]),
+                day=min(local_completed.day, monthrange(year, month)[1]),
             )
         # First candidate: same month if the resolved day is still ahead.
         candidate_year, candidate_month = local_completed.year, local_completed.month
@@ -569,7 +569,7 @@ def _next_monthly_target(task: dict, local_completed: datetime, value: int) -> d
             year, month = _add_months(local_completed.year, local_completed.month, value)
             return local_completed.replace(
                 year=year, month=month,
-                day=min(local_completed.day, calendar.monthrange(year, month)[1]),
+                day=min(local_completed.day, monthrange(year, month)[1]),
             )
         weekday = weekdays[0]
         # Try the same month first; if that hit is not strictly after completion,
@@ -584,7 +584,7 @@ def _next_monthly_target(task: dict, local_completed: datetime, value: int) -> d
 
     # No pattern → simple "every N months from completion" behaviour.
     year, month = _add_months(local_completed.year, local_completed.month, value)
-    day = min(local_completed.day, calendar.monthrange(year, month)[1])
+    day = min(local_completed.day, monthrange(year, month)[1])
     return local_completed.replace(year=year, month=month, day=day)
 
 
@@ -600,17 +600,17 @@ def _next_yearly_target(task: dict, local_completed: datetime, value: int) -> da
             month = local_completed.month
         # Try the current year's anniversary; if it's already past, jump *value* years.
         candidate_year = local_completed.year
-        day = min(anchor_day, calendar.monthrange(candidate_year, month)[1])
+        day = min(anchor_day, monthrange(candidate_year, month)[1])
         candidate = local_completed.replace(year=candidate_year, month=month, day=day)
         if candidate.date() <= local_completed.date():
             candidate_year += value
-            day = min(anchor_day, calendar.monthrange(candidate_year, month)[1])
+            day = min(anchor_day, monthrange(candidate_year, month)[1])
             candidate = local_completed.replace(year=candidate_year, month=month, day=day)
         return candidate
 
     # No anchor → "every N years from completion" with leap-year clamping.
     year = local_completed.year + value
-    day = min(local_completed.day, calendar.monthrange(year, local_completed.month)[1])
+    day = min(local_completed.day, monthrange(year, local_completed.month)[1])
     return local_completed.replace(year=year, day=day)
 
 


### PR DESCRIPTION
## Problem

Completing a task with a **monthly or yearly** recurrence crashes with:

```
AttributeError: module 'custom_components.home_tasks.calendar' has no attribute 'monthrange'
```

The exception aborts `_on_task_completed` mid-flight: the store save never happens, so the completion isn't persisted (it reappears on refresh), the due date is never advanced, and the reopen timer is never scheduled. Daily/weekly recurrences and non-recurring tasks are unaffected.

Fixes #21.

## Root cause

`__init__.py` does `import calendar` (stdlib) at the top. But when Home Assistant sets up the integration's `calendar` **platform**, Python's import machinery binds the imported submodule as the `calendar` attribute of the parent package — and a package's namespace *is* its `__init__.py` module namespace. This silently rebinds the global name `calendar` from the stdlib module to `custom_components.home_tasks.calendar`.

So the bug is deterministic: as soon as the calendar platform has been loaded, every `calendar.monthrange()` call in `__init__.py` hits the platform module instead of the stdlib. It doesn't reproduce in unit tests that import the helpers without a full platform setup, which is presumably why it slipped through.

`monthrange` is only used by the monthly/yearly target computation (`_next_monthly_target`, `_next_yearly_target`, `_resolve_dom`, `_resolve_nth_weekday`), which matches the reported symptom exactly.

## Fix

Import the function directly:

```python
from calendar import monthrange
```

The `monthrange` binding is never touched by the platform import, so all 8 call sites now reliably resolve to the stdlib function. (An `import calendar as _cal` alias would work too for the same reason — only the bare name `calendar` gets rebound — but the direct function import is the smallest change.)

Diagnosed on a live HA 2026.6.2 / v1.13.1 install where the failure mode was reproduced (completion of monthly/yearly recurring tasks aborts before the store save, no history entry, no due-date advance — exactly as reported in #21). The same one-line hotfix has been applied to that install; I'll report back after the restart/retest cycle confirms the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)