### PR TITLE
Add live search over existing tasks in add-task field

### DIFF
--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -88,6 +88,8 @@ const _TRANSLATIONS = {
     ed_show_tag_chips: "Tag filter",
     ed_show_person_chips: "Person filter",
     ed_show_voice: "Voice input",
+    /* CUSTOM PATCH: Editor-Label für den neuen "Task search" Toggle */
+    ed_task_search: "Task search",
     ed_auto_image: "Auto-generate image",
     ed_show_priority: "Priorities",
     ed_default_sort: "Default sort",
@@ -1273,6 +1275,8 @@ const _TRANSLATIONS = {
     ed_show_tag_chips: "Tag-Filter",
     ed_show_person_chips: "Personen-Filter",
     ed_show_voice: "Spracheingabe",
+    /* CUSTOM PATCH: Editor-Label für den neuen "Aufgaben-Suche" Toggle */
+    ed_task_search: "Aufgaben-Suche",
     ed_auto_image: "Bild automatisch generieren",
     ed_default_sort: "Standard-Sortierung",
     reminder: "Erinnerungen",
@@ -1465,7 +1469,9 @@ class HomeTasksCard extends HTMLElement {
   }
 
   _defaultColState() {
-    return { filter: "all", sortBy: "manual", sortOpen: false, tagFilters: new Set(), personFilters: new Set(), tasks: [], sections: [], newTaskTitle: "", newTaskDue: "", newTaskDueTime: "" };
+    // CUSTOM PATCH: taskSearchQuery hält den aktuell getippten Suchtext im
+    // Add-Task-Feld (siehe _buildColumnAddTask / _buildColumnTaskList).
+    return { filter: "all", sortBy: "manual", sortOpen: false, tagFilters: new Set(), personFilters: new Set(), tasks: [], sections: [], newTaskTitle: "", newTaskDue: "", newTaskDueTime: "", taskSearchQuery: "" };
   }
 
   _t(key, ...args) {
@@ -1900,6 +1906,8 @@ class HomeTasksCard extends HTMLElement {
     const cs = this._columns[colIdx];
     const title = cs.newTaskTitle.trim();
     if (!title) return;
+    // CUSTOM PATCH: Hinzufügen einer Aufgabe beendet eine evtl. aktive Suche.
+    cs.taskSearchQuery = "";
     if (!this._colListId(colIdx) && !this._colEntityId(colIdx)) return;
 
     // Capture add-input position for the entry animation
@@ -1978,7 +1986,21 @@ class HomeTasksCard extends HTMLElement {
     }
   }
 
+  // CUSTOM PATCH: Wrapper um die ursprüngliche _toggleTask-Logik. Merkt
+  // sich, ob beim Abhaken gerade eine Suche aktiv war, und beendet diese
+  // danach automatisch (Eingabefeld leeren, Sektionsansicht wiederherstellen).
   async _toggleTask(taskId, completed, colIdx) {
+    const cs = this._columns[colIdx];
+    const wasSearching = !!(cs && cs.taskSearchQuery && cs.taskSearchQuery.trim());
+    await this._toggleTaskCore(taskId, completed, colIdx);
+    if (wasSearching) {
+      cs.taskSearchQuery = "";
+      cs.newTaskTitle = "";
+      this._render();
+    }
+  }
+
+  async _toggleTaskCore(taskId, completed, colIdx) {
     const col = this._config.columns[colIdx];
     const cs = this._columns[colIdx];
     const newCompleted = !completed;
@@ -3340,18 +3362,74 @@ class HomeTasksCard extends HTMLElement {
     }
   }
 
+  // ============================================================
+  // CUSTOM PATCH: Gezieltes Update NUR der Aufgabenliste, ohne das
+  // Eingabefeld (und damit die Bildschirmtastatur am Handy) anzufassen.
+  //
+  // Warum nötig: this._render() baut die komplette Karte neu auf — auch
+  // wenn Fokus/Cursor über data-focus-key hinterher wiederhergestellt
+  // werden, wird das <input>-DOM-Element dabei technisch entfernt und neu
+  // erzeugt. Am Handy führt genau das dazu, dass die virtuelle Tastatur
+  // bei jedem Tastendruck kurz zu- und wieder aufklappt (sichtbares
+  // Flackern). Diese Methode ersetzt stattdessen NUR den bestehenden
+  // ".task-list"-Container im Shadow-DOM durch eine frisch gebaute
+  // Version — das <input>-Element bleibt die ganze Zeit unangetastet und
+  // behält Fokus + offene Tastatur durchgehend.
+  // ============================================================
+  _refreshTaskListDOM(colIdx) {
+    const col = this._config.columns[colIdx];
+    // Kachel-Ansicht hat einen eigenen Aufbau-Pfad (_buildColumnTileGrid),
+    // der hier nicht angebunden ist — dort im Zweifel auf volles _render()
+    // zurückfallen, statt einen zweiten Spezialfall nachzubauen.
+    if (col.view_mode === "tiles") { this._render(); return; }
+
+    const filteredTasks = this._filteredTasks(colIdx);
+    const newList = this._buildColumnTaskList(filteredTasks, colIdx);
+    const oldList = this.shadowRoot.querySelector(`.task-list[data-col-idx="${colIdx}"]`);
+    if (oldList && oldList.parentNode) {
+      oldList.replaceWith(newList);
+    } else {
+      this._render();
+    }
+  }
+
   _buildColumnAddTask(cs, colIdx) {
     const col = this._config.columns[colIdx];
+    // CUSTOM PATCH: über den Config-Toggle "show_task_search" abschaltbar
+    // (Default an). Editor-Schalter siehe HomeTasksCardEditor weiter unten.
+    const searchEnabled = col.show_task_search !== false;
+
     const addInput = this._el("input", {
       type: "text",
       className: "add-input",
       placeholder: this._t("add_placeholder"),
       value: cs.newTaskTitle,
       "data-focus-key": `add_task_col_${colIdx}`,
+      autocomplete: "off",
     });
-    addInput.addEventListener("input", (e) => { cs.newTaskTitle = e.target.value; });
+    addInput.addEventListener("input", (e) => {
+      cs.newTaskTitle = e.target.value;
+      if (searchEnabled) {
+        // CUSTOM PATCH: Sucheingabe spiegeln + NUR die Liste aktualisieren
+        // (siehe _refreshTaskListDOM oben — kein this._render() hier,
+        // damit die Handy-Tastatur beim Tippen nicht flackert).
+        cs.taskSearchQuery = e.target.value.trim();
+        this._refreshTaskListDOM(colIdx);
+      }
+    });
     addInput.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") this._addTask(colIdx);
+      if (e.key === "Enter") {
+        this._addTask(colIdx);
+      } else if (searchEnabled && e.key === "Escape" && cs.taskSearchQuery) {
+        // CUSTOM PATCH: Escape bricht die Suche ab, Sektionsansicht kommt
+        // zurück. Gezieltes Update statt _render(), aus demselben Grund
+        // wie oben (kein Tastatur-Flackern).
+        e.preventDefault();
+        addInput.value = "";
+        cs.newTaskTitle = "";
+        cs.taskSearchQuery = "";
+        this._refreshTaskListDOM(colIdx);
+      }
     });
     const addBtn = this._el("button", { className: "add-btn", textContent: "+" });
     addBtn.addEventListener("click", () => this._addTask(colIdx));
@@ -3591,9 +3669,49 @@ class HomeTasksCard extends HTMLElement {
       : null;
   }
 
+  // ============================================================
+  // CUSTOM PATCH: Live-Such-Trefferliste.
+  //
+  // Ersetzt bei aktiver Suche (cs.taskSearchQuery gesetzt) die normale,
+  // nach Sektionen gruppierte Ansicht durch eine flache Liste aller
+  // Treffer (offen + erledigt, quer über alle Sektionen), damit auf dem
+  // Handy nicht der ganze Platz von Sektions-Headern (Spar/Hofer/
+  // Bäckerei/...) belegt wird. Ignoriert bewusst den aktiven
+  // All/Open/Done-Filter und die Tag-/Personen-Chips.
+  // ============================================================
+  _buildTaskSearchResults(query, colIdx) {
+    const cs = this._columns[colIdx];
+    const q = query.toLowerCase();
+    const matches = (cs.tasks || [])
+      .filter((t) => t.title && t.title.toLowerCase().includes(q))
+      .sort((a, b) => {
+        const aStarts = a.title.toLowerCase().startsWith(q) ? 0 : 1;
+        const bStarts = b.title.toLowerCase().startsWith(q) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        return a.title.localeCompare(b.title);
+      });
+
+    const children = [];
+    if (matches.length === 0) {
+      children.push(this._el("div", { className: "task-search-empty", textContent: this._t("empty") }));
+    } else {
+      for (const task of matches) children.push(this._buildTask(task, colIdx));
+    }
+    return this._el("div", { className: "task-list", "data-col-idx": String(colIdx) }, children);
+  }
+
   _buildColumnTaskList(filteredTasks, colIdx) {
     const cs = this._columns[colIdx];
     const col = this._config.columns[colIdx];
+
+    // CUSTOM PATCH: Bei aktiver Suche (und Feature nicht per Editor-Toggle
+    // deaktiviert) hier abzweigen.
+    const searchEnabled = col.show_task_search !== false;
+    const activeQuery = searchEnabled ? (cs.taskSearchQuery || "").trim() : "";
+    if (activeQuery) {
+      return this._buildTaskSearchResults(activeQuery, colIdx);
+    }
+
     const sections = (cs.sections || []).slice().sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
 
     const taskListChildren = [];
@@ -7254,6 +7372,11 @@ class HomeTasksCard extends HTMLElement {
         padding: 8px 14px; font-size: 12px; font-style: italic;
         color: var(--todo-secondary-text);
       }
+      /* CUSTOM PATCH: "Keine Treffer"-Text in der Such-Trefferliste. */
+      .task-search-empty {
+        padding: 24px 8px; text-align: center; font-size: 13px; font-style: italic;
+        color: var(--todo-secondary-text);
+      }
       .recurrence-toggle-row { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
       .recurrence-input-row { display: flex; align-items: flex-end; gap: 8px; }
       .rec-remaining { font-size: 12px; color: var(--secondary-text-color); align-self: center; flex-shrink: 0; }
@@ -8803,6 +8926,8 @@ class HomeTasksCardEditor extends HTMLElement {
           makeToggle("show-title", "ed_show_title", "show_title", true),
           makeToggle("show-progress", "ed_show_progress", "show_progress", true),
           makeToggle("show-add-task", "ed_show_add_task", "show_add_task", true),
+          // CUSTOM PATCH: Ein/Aus-Schalter für die Live-Suche im Add-Task-Feld.
+          makeToggle("task-search", "ed_task_search", "show_task_search", true),
           makeToggle("show-add-due", "ed_show_add_due", "show_add_due", false),
           makeToggle("auto-delete", "ed_auto_delete", "auto_delete_completed", false),
           makeToggle("confirm-complete", "ed_confirm_complete", "confirm_complete", false),


### PR DESCRIPTION
While typing in the add-task input, live-filter the column's task list (open + completed) by title match instead of adding a duplicate. Section headers are hidden during search and reappear once the search is cleared (Escape, adding the task, or checking off a matched task). Toggleable per column via a new "Task search" editor switch (default on).