### PR TITLE
Add image support for external todo tasks

### DIFF
--- a/custom_components/home_tasks/home-tasks-card.js
+++ b/custom_components/home_tasks/home-tasks-card.js
@@ -4667,7 +4667,7 @@ class HomeTasksCard extends HTMLElement {
     if (col.show_reminders !== false) details.push(this._buildRemindersSection(task, colIdx));
     if (col.show_recurrence !== false) details.push(this._buildRecurrenceSection(task, colIdx));
     if (col.show_history) details.push(this._buildHistorySection(task));
-    if (!this._isExternalCol(colIdx) && col.show_images === true) details.push(this._buildImageSection(task, colIdx));
+    if (col.show_images === true) details.push(this._buildImageSection(task, colIdx));
     details.push(this._buildActionsSection(task, colIdx));
 
     const inner = this._el("div", { className: "task-details-inner" }, details);
@@ -6107,10 +6107,8 @@ class HomeTasksCard extends HTMLElement {
       // Remove image button (×)
       const removeBtn = this._el("button", { className: "task-image-remove", title: this._t("img_remove") });
       removeBtn.innerHTML = `<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>`;
-      // Reuse _saveImageUrl(null): it clears the image, syncs cs.tasks in EVERY
-      // column from the server result, and refreshes the open sheet + all tiles
-      // (the old inline copy only patched the current column, so the same task in
-      // other columns kept showing the deleted image).
+      // Reuse _saveImageUrl(null): it clears the image in the source column and
+      // refreshes the open sheet + visible tiles without a full render.
       removeBtn.addEventListener("click", () => this._saveImageUrl(task, colIdx, null));
       imgWrap.appendChild(removeBtn);
       children.push(imgWrap);
@@ -6313,20 +6311,23 @@ class HomeTasksCard extends HTMLElement {
 
     const payload = {
       type: "home_tasks/generate_task_image",
-      entry_id: col.list_id,
       task_id: task.id,
       force: force,
     };
+    if (col.entity_id) payload.todo_entity_id = col.entity_id;
+    else payload.entry_id = col.list_id;
     if (imgCfg.prompt_prefix) payload.prompt_prefix = imgCfg.prompt_prefix;
     if (imgCfg.entity_id) payload.entity_id = imgCfg.entity_id;
 
     try {
       const result = await this._hass.callWS(payload);
       // Update every column immediately.
-      // • Exact ID match  → full task replacement (the generating task itself).
+      // • Exact ID match in the source column → full task replacement.
       // • Same title, different ID → image_url-only patch (same-title tasks in
       //   other lists that the backend also updated — they share the image but
       //   have their own task objects).
+      // External providers may use overlapping task IDs, so an ID match in a
+      // different column must never replace that column's task object.
       const newImageUrl = result.task?.image_url;
       const titleKey = (task.title || "").trim().toLowerCase();
       for (let ci = 0; ci < this._columns.length; ci++) {
@@ -6334,7 +6335,7 @@ class HomeTasksCard extends HTMLElement {
         if (!cs || !cs.tasks) continue;
         for (let i = 0; i < cs.tasks.length; i++) {
           const t = cs.tasks[i];
-          if (t.id === task.id) {
+          if (ci === colIdx && t.id === task.id) {
             cs.tasks[i] = result.task;
           } else if (newImageUrl && titleKey && (t.title || "").trim().toLowerCase() === titleKey) {
             cs.tasks[i] = { ...t, image_url: newImageUrl };
@@ -6379,19 +6380,28 @@ class HomeTasksCard extends HTMLElement {
   async _saveImageUrl(task, colIdx, url) {
     const col = this._config.columns[colIdx];
     try {
-      const result = await this._hass.callWS({
-        type: "home_tasks/update_task",
-        list_id: col.list_id,
-        task_id: task.id,
-        image_url: url,
-      });
-      // Update every column so the change is visible immediately everywhere.
-      for (let ci = 0; ci < this._columns.length; ci++) {
-        const cs = this._columns[ci];
-        if (!cs || !cs.tasks) continue;
-        const idx = cs.tasks.findIndex(t => t.id === task.id);
-        if (idx >= 0) cs.tasks[idx] = result;
+      let result;
+      if (col.entity_id) {
+        const overlay = await this._hass.callWS({
+          type: "home_tasks/update_external_overlay",
+          entity_id: col.entity_id,
+          task_uid: task.id,
+          image_url: url,
+        });
+        result = { ...task, ...overlay };
+      } else {
+        result = await this._hass.callWS({
+          type: "home_tasks/update_task",
+          list_id: col.list_id,
+          task_id: task.id,
+          image_url: url,
+        });
       }
+      // Replace only the source task. External providers may use overlapping
+      // task IDs, so updating all columns by ID could corrupt another list.
+      const cs = this._columns[colIdx];
+      const idx = cs?.tasks?.findIndex(t => t.id === task.id) ?? -1;
+      if (idx >= 0) cs.tasks[idx] = result;
       // Update the open sheet + tiles in place (a full _render() would keep the
       // old sheet DOM — showing the old image — and reset the scroll position).
       this._refreshOpenSheetImage(task.id, colIdx);

--- a/custom_components/home_tasks/overlay_store.py
+++ b/custom_components/home_tasks/overlay_store.py
@@ -64,6 +64,7 @@ OVERLAY_FIELDS = (
     "history",
     "completed_at",
     "section_id",
+    "image_url",
 )
 
 _MAX_HISTORY = 50
@@ -99,6 +100,7 @@ def _empty_overlay() -> dict:
         "history": [],
         "completed_at": None,
         "section_id": None,
+        "image_url": None,
     }
 
 

--- a/custom_components/home_tasks/websocket_api.py
+++ b/custom_components/home_tasks/websocket_api.py
@@ -750,8 +750,11 @@ async def async_move_task_any(
         else:
             generic = GenericAdapter(hass, src_entity_id, {})
             await generic.async_delete_task(task_id)
-        # Clean up overlay
+        # Clean up overlay and delete its image file when the move did not
+        # transfer a reference to the target task.
+        old_image_url = src_overlay.get_overlay(task_id).get("image_url")
         await src_overlay.async_delete_overlay(task_id)
+        await _cleanup_orphan_image(hass, old_image_url, None)
 
 
 
@@ -858,6 +861,7 @@ def _merge_tasks_with_overlays(
             "assigned_person": overlay.get("assigned_person"),
             "tags": overlay.get("tags", []),
             "history": overlay.get("history", []),
+            "image_url": overlay.get("image_url"),
             # Mark as external so the card knows how to route CRUD
             "_external": True,
         }
@@ -941,6 +945,7 @@ def _merge_tasks_with_adapter_data(
             # History & completed_at always from overlay
             "completed_at": overlay.get("completed_at"),
             "history": overlay.get("history", []),
+            "image_url": overlay.get("image_url"),
             # Todoist recurrence string for read-only display
             "_todoist_recurrence_string": item.get("_todoist_recurrence_string"),
             # Mark as external
@@ -1000,6 +1005,27 @@ async def ws_get_external_lists(hass, connection, msg):
         _handle_error(connection, msg["id"], err)
 
 
+async def _async_get_external_tasks(hass, entity_id: str) -> tuple[list[dict], ExternalTaskOverlayStore]:
+    """Read an external list and merge provider data with its local overlay."""
+    overlay_store = _get_overlay_store(hass, entity_id)
+    adapter = _get_adapter(hass, entity_id)
+
+    if adapter and not isinstance(adapter, GenericAdapter):
+        external_items = await adapter.async_read_tasks()
+        tasks = _merge_tasks_with_adapter_data(
+            external_items, overlay_store, adapter.capabilities,
+        )
+    else:
+        external_items = _get_external_todo_items(hass, entity_id)
+        features = 0
+        state = hass.states.get(entity_id)
+        if state and state.attributes:
+            features = state.attributes.get("supported_features", 0)
+        provider_owns_order = bool(features & 8)  # MOVE_TODO_ITEM
+        tasks = _merge_tasks_with_overlays(external_items, overlay_store, provider_owns_order)
+    return tasks, overlay_store
+
+
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "home_tasks/get_external_tasks",
@@ -1010,25 +1036,7 @@ async def ws_get_external_lists(hass, connection, msg):
 async def ws_get_external_tasks(hass, connection, msg):
     """Get tasks from an external todo entity, merged with overlay data."""
     try:
-        entity_id = msg["entity_id"]
-        overlay_store = _get_overlay_store(hass, entity_id)
-        adapter = _get_adapter(hass, entity_id)
-
-        if adapter and not isinstance(adapter, GenericAdapter):
-            # Rich adapter (e.g. Todoist) — read directly from provider API
-            external_items = await adapter.async_read_tasks()
-            tasks = _merge_tasks_with_adapter_data(
-                external_items, overlay_store, adapter.capabilities,
-            )
-        else:
-            # Generic path — read via HA todo entity + overlay
-            external_items = _get_external_todo_items(hass, entity_id)
-            features = 0
-            state = hass.states.get(entity_id)
-            if state and state.attributes:
-                features = state.attributes.get("supported_features", 0)
-            provider_owns_order = bool(features & 8)  # MOVE_TODO_ITEM
-            tasks = _merge_tasks_with_overlays(external_items, overlay_store, provider_owns_order)
+        tasks, overlay_store = await _async_get_external_tasks(hass, msg["entity_id"])
 
         connection.send_result(msg["id"], {"tasks": tasks, "sections": overlay_store.sections})
     except Exception as err:
@@ -1062,6 +1070,9 @@ async def ws_get_external_tasks(hass, connection, msg):
         vol.Optional("recurrence_nth_week"): vol.Any(vol.All(int, vol.Range(min=1, max=4)), "last", None),
         vol.Optional("recurrence_anniversary"): _val_anniversary,
         vol.Optional("section_id"): vol.Any(_val_id, None),
+        vol.Optional("image_url"): vol.Any(
+            vol.All(str, vol.Length(max=MAX_IMAGE_URL_LENGTH)), None
+        ),
     }
 )
 @websocket_api.async_response
@@ -1069,11 +1080,14 @@ async def ws_update_external_overlay(hass, connection, msg):
     """Update overlay fields for an external task."""
     try:
         overlay_store = _get_overlay_store(hass, msg["entity_id"])
+        old_image_url = overlay_store.get_overlay(msg["task_uid"]).get("image_url")
         kwargs = {}
         for key in OVERLAY_FIELDS:
             if key in msg:
                 kwargs[key] = msg[key]
         overlay = await overlay_store.async_set_overlay(msg["task_uid"], **kwargs)
+        if "image_url" in kwargs:
+            await _cleanup_orphan_image(hass, old_image_url, kwargs["image_url"])
         connection.send_result(msg["id"], overlay)
     except Exception as err:
         _handle_error(connection, msg["id"], err)
@@ -1447,7 +1461,9 @@ async def ws_delete_external_overlay(hass, connection, msg):
     """Delete overlay data for an external task (cleanup after deletion)."""
     try:
         overlay_store = _get_overlay_store(hass, msg["entity_id"])
+        old_image_url = overlay_store.get_overlay(msg["task_uid"]).get("image_url")
         await overlay_store.async_delete_overlay(msg["task_uid"])
+        await _cleanup_orphan_image(hass, old_image_url, None)
         # Cancel any pending reminder/recurrence timers so they don't fire (and
         # leak) for a task that no longer exists.
         from . import _cancel_recurrence, _cancel_reminders
@@ -1617,12 +1633,15 @@ async def _cleanup_orphan_image(hass, old_url: str | None, new_url: str | None) 
     if new_url and _local_image_name(new_url) is None:
         return
     for s in hass.data.get(DOMAIN, {}).values():
-        if not hasattr(s, "tasks"):
+        if isinstance(s, ExternalTaskOverlayStore):
+            tasks = s.get_all_overlays().values()
+        elif hasattr(s, "tasks"):
+            # Membership only — read the raw list instead of the .tasks property,
+            # which builds a freshly-sorted copy on every access.
+            raw = getattr(s, "_data", None)
+            tasks = raw["tasks"] if isinstance(raw, dict) and "tasks" in raw else s.tasks
+        else:
             continue
-        # Membership only — read the raw list instead of the .tasks property,
-        # which builds a freshly-sorted copy on every access.
-        raw = getattr(s, "_data", None)
-        tasks = raw["tasks"] if isinstance(raw, dict) and "tasks" in raw else s.tasks
         for t in tasks:
             if _local_image_name(t.get("image_url")) == old_name:
                 return  # still referenced — keep the file
@@ -1844,8 +1863,9 @@ async def _save_image_to_public_media(hass, connection, image_url: str, filename
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "home_tasks/generate_task_image",
-        vol.Required("entry_id"): _val_id,
-        vol.Required("task_id"): _val_id,
+        vol.Optional("entry_id"): _val_id,
+        vol.Optional("todo_entity_id"): _val_entity_id,
+        vol.Required("task_id"): _val_task_uid,
         vol.Optional("prompt_prefix"): vol.All(str, vol.Length(max=200)),
         vol.Optional("entity_id"): _val_entity_id,
         vol.Optional("force"): bool,
@@ -1860,14 +1880,34 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
     lands in HA's Media Source; no API key handling or file I/O needed here.
 
     Tasks with the same normalised title share a single image: before calling
-    the service the stores are checked for an existing URL.  After generation
-    the URL is propagated to every task with the same title across all lists.
+    the service the native stores and selected external list are checked for
+    an existing URL. After generation the URL is propagated to matching native
+    tasks and matching tasks in the selected external list.
     """
     import hashlib
 
     try:
-        store = _get_store(hass, msg["entry_id"])
-        task = store.get_task(msg["task_id"])
+        entry_id = msg.get("entry_id")
+        todo_entity_id = msg.get("todo_entity_id")
+        if bool(entry_id) == bool(todo_entity_id):
+            raise ValueError("Provide exactly one of entry_id or todo_entity_id")
+
+        store = None
+        overlay_store = None
+        external_tasks: list[dict] = []
+        if todo_entity_id:
+            external_tasks, overlay_store = await _async_get_external_tasks(
+                hass, todo_entity_id
+            )
+            task = next(
+                (candidate for candidate in external_tasks if candidate["id"] == msg["task_id"]),
+                None,
+            )
+            if task is None:
+                raise ValueError("Task not found")
+        else:
+            store = _get_store(hass, entry_id)
+            task = store.get_task(msg["task_id"])
 
         title = task.get("title", "")
         title_key = title.strip().lower()
@@ -1891,8 +1931,25 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
                 if existing_url:
                     break
 
+            if not existing_url:
+                for candidate in external_tasks:
+                    if (
+                        candidate.get("title", "").strip().lower() == title_key
+                        and candidate.get("image_url")
+                    ):
+                        existing_url = candidate["image_url"]
+                        break
+
             if existing_url:
-                updated_task = await store.async_update_task(msg["task_id"], image_url=existing_url)
+                if overlay_store:
+                    await overlay_store.async_set_overlay(
+                        msg["task_id"], image_url=existing_url
+                    )
+                    updated_task = {**task, "image_url": existing_url}
+                else:
+                    updated_task = await store.async_update_task(
+                        msg["task_id"], image_url=existing_url
+                    )
                 connection.send_result(msg["id"], {"task": updated_task})
                 return
 
@@ -1969,7 +2026,8 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
             image_url = f"{image_url}?v={int(time.time())}"
 
         # ------------------------------------------------------------------
-        # 3. Propagate URL to every task with the same title across all lists.
+        # 3. Propagate the URL to matching native tasks and to matching tasks
+        #    in the selected external list.
         # ------------------------------------------------------------------
         updated_task = None
         # Only fan out to same-title tasks when the title is non-empty — an empty
@@ -1985,8 +2043,28 @@ async def ws_generate_task_image(hass: HomeAssistant, connection, msg):
                         if t["id"] == msg["task_id"]:
                             updated_task = stamped
 
+            # External provider tasks keep Home Tasks-only image metadata in
+            # their overlay; Todoist itself is never edited by this operation.
+            if overlay_store:
+                for candidate in external_tasks:
+                    if (
+                        candidate.get("title", "").strip().lower() == title_key
+                        and candidate.get("image_url") != image_url
+                    ):
+                        await overlay_store.async_set_overlay(
+                            candidate["id"], image_url=image_url
+                        )
+                        if candidate["id"] == msg["task_id"]:
+                            updated_task = {**candidate, "image_url": image_url}
+
         if updated_task is None:
-            updated_task = await store.async_update_task(msg["task_id"], image_url=image_url)
+            if overlay_store:
+                await overlay_store.async_set_overlay(msg["task_id"], image_url=image_url)
+                updated_task = {**task, "image_url": image_url}
+            else:
+                updated_task = await store.async_update_task(
+                    msg["task_id"], image_url=image_url
+                )
 
         connection.send_result(msg["id"], {"task": updated_task})
 

--- a/tests-js/test_external_images.mjs
+++ b/tests-js/test_external_images.mjs
@@ -1,0 +1,125 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadCard, makeMockHass } from './setup.mjs';
+
+async function externalCard(callWS) {
+  const { HomeTasksCard } = await loadCard({ force: true });
+  const card = new HomeTasksCard();
+  card.setConfig({
+    image_generation: { entity_id: 'ai_task.google_ai_task' },
+    columns: [{
+      entity_id: 'todo.do_zrobienia',
+      show_images: true,
+    }],
+  });
+  card._hass = makeMockHass({ callWS });
+  card._refreshOpenSheetImage = () => {};
+  card._refreshTaskTileEverywhere = () => {};
+  return card;
+}
+
+describe('external task images', () => {
+  test('shows image controls in external task details', async () => {
+    const card = await externalCard(async () => null);
+    const details = card._buildTaskDetails({
+      id: 'todoist-details',
+      title: 'External task',
+      image_url: '/local/home_tasks/external.png',
+      tags: [],
+      reminders: [],
+      sub_items: [],
+      history: [],
+    }, 0);
+
+    assert.ok(details.querySelector('.detail-section--image'));
+    assert.equal(
+      details.querySelector('.task-image')?.getAttribute('src'),
+      '/local/home_tasks/external.png',
+    );
+    assert.ok(details.querySelector('.generate-image-btn'));
+  });
+
+  test('routes generation to the Todoist entity, not a native list', async () => {
+    let payload;
+    const card = await externalCard(async (msg) => {
+      payload = msg;
+      return {
+        task: {
+          id: 'todoist-1',
+          title: 'Buy milk',
+          image_url: '/local/home_tasks/generated.png',
+        },
+      };
+    });
+    card._columns[0].tasks = [{ id: 'todoist-1', title: 'Buy milk' }];
+
+    await card._generateTaskImage(card._columns[0].tasks[0], 0);
+
+    assert.equal(payload.todo_entity_id, 'todo.do_zrobienia');
+    assert.equal(payload.entry_id, undefined);
+    assert.equal(payload.entity_id, 'ai_task.google_ai_task');
+    assert.equal(payload.task_id, 'todoist-1');
+  });
+
+  test('does not replace a same-ID task from another external list', async () => {
+    const card = await externalCard(async () => ({
+      task: {
+        id: 'shared-id',
+        title: 'Buy milk',
+        description: 'Source description',
+        image_url: '/local/home_tasks/generated.png',
+      },
+    }));
+    card._config.columns.push({
+      entity_id: 'todo.other_list',
+      show_images: true,
+    });
+    card._columns.push({
+      tasks: [{ id: 'shared-id', title: 'Unrelated task', description: 'Keep me' }],
+    });
+    card._columns[0].tasks = [{ id: 'shared-id', title: 'Buy milk' }];
+
+    await card._generateTaskImage(card._columns[0].tasks[0], 0);
+
+    assert.equal(card._columns[0].tasks[0].description, 'Source description');
+    assert.deepEqual(card._columns[1].tasks[0], {
+      id: 'shared-id',
+      title: 'Unrelated task',
+      description: 'Keep me',
+    });
+  });
+
+  test('saves an external image URL in the overlay', async () => {
+    let payload;
+    const card = await externalCard(async (msg) => {
+      payload = msg;
+      return { image_url: msg.image_url };
+    });
+    const task = { id: 'todoist-2', title: 'Call dentist' };
+    card._columns[0].tasks = [task];
+
+    await card._saveImageUrl(task, 0, '/local/home_tasks/dentist.png');
+
+    assert.equal(payload.type, 'home_tasks/update_external_overlay');
+    assert.equal(payload.entity_id, 'todo.do_zrobienia');
+    assert.equal(payload.task_uid, 'todoist-2');
+    assert.equal(payload.image_url, '/local/home_tasks/dentist.png');
+    assert.equal(card._columns[0].tasks[0].image_url, '/local/home_tasks/dentist.png');
+  });
+
+  test('manual image changes do not replace a same-ID task in another list', async () => {
+    const card = await externalCard(async (msg) => ({ image_url: msg.image_url }));
+    card._config.columns.push({ entity_id: 'todo.other_list', show_images: true });
+    card._columns.push({
+      tasks: [{ id: 'shared-id', title: 'Other task', image_url: '/local/other.png' }],
+    });
+    const task = { id: 'shared-id', title: 'Source task' };
+    card._columns[0].tasks = [task];
+
+    await card._saveImageUrl(task, 0, '/local/source.png');
+
+    assert.equal(card._columns[0].tasks[0].image_url, '/local/source.png');
+    assert.equal(card._columns[1].tasks[0].image_url, '/local/other.png');
+    assert.equal(card._columns[1].tasks[0].title, 'Other task');
+  });
+});

--- a/tests/integration/test_websocket_api.py
+++ b/tests/integration/test_websocket_api.py
@@ -335,6 +335,23 @@ async def test_ws_update_external_overlay(
     assert "work" in msg["result"]["tags"]
 
 
+async def test_ws_update_external_overlay_image_url(
+    hass: HomeAssistant, hass_ws_client, external_config_entry
+) -> None:
+    """An external task image URL is stored without changing the provider task."""
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        "id": 211,
+        "type": "home_tasks/update_external_overlay",
+        "entity_id": "todo.ws_external",
+        "task_uid": "ext-image-1",
+        "image_url": "/local/home_tasks/external.png?v=1",
+    })
+    msg = await client.receive_json()
+    assert msg["success"] is True
+    assert msg["result"]["image_url"] == "/local/home_tasks/external.png?v=1"
+
+
 async def test_ws_add_external_sub_task(
     hass: HomeAssistant, hass_ws_client, external_config_entry
 ) -> None:
@@ -530,7 +547,12 @@ async def test_ws_get_external_tasks_merges_overlay(
     from custom_components.home_tasks.overlay_store import ExternalTaskOverlayStore
     overlay_store = hass.data[DOMAIN][external_config_entry.entry_id]
     assert isinstance(overlay_store, ExternalTaskOverlayStore)
-    await overlay_store.async_set_overlay("ext-1", priority=3, tags=["urgent"])
+    await overlay_store.async_set_overlay(
+        "ext-1",
+        priority=3,
+        tags=["urgent"],
+        image_url="/local/home_tasks/ext-1.png",
+    )
 
     client = await hass_ws_client(hass)
     await client.send_json({
@@ -548,10 +570,78 @@ async def test_ws_get_external_tasks_merges_overlay(
     assert task_a["priority"] == 3
     assert task_a["tags"] == ["urgent"]
     assert task_a["due_date"] == "2026-06-15"
+    assert task_a["image_url"] == "/local/home_tasks/ext-1.png"
     assert task_a["_external"] is True
 
     task_b = next(t for t in tasks if t["id"] == "ext-2")
     assert task_b["completed"] is True
+
+
+async def test_generate_image_for_external_task_uses_title_only(
+    hass: HomeAssistant, hass_ws_client, external_config_entry
+) -> None:
+    """Todoist images persist in overlay and disclose no task metadata but title."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from homeassistant.components.todo import TodoItem, TodoItemStatus
+    from homeassistant.core import SupportsResponse
+
+    mock_entity = MagicMock()
+    mock_entity.todo_items = [
+        TodoItem(
+            uid="todoist-1",
+            summary="Buy milk",
+            description="PRIVATE NOTE MUST NOT BE SENT",
+            status=TodoItemStatus.NEEDS_ACTION,
+        )
+    ]
+    mock_comp = MagicMock()
+    mock_comp.get_entity.return_value = mock_entity
+    hass.data["todo"] = mock_comp
+    hass.states.async_set("todo.ws_external", "1")
+
+    calls = []
+
+    async def _generate(call):  # noqa: ANN001
+        calls.append(call.data)
+        return {"media_source_id": "media-source://media_source/generated.png"}
+
+    hass.services.async_register(
+        "ai_task",
+        "generate_image",
+        _generate,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    client = await hass_ws_client(hass)
+    with patch(
+        "custom_components.home_tasks.websocket_api._save_image_to_public_media",
+        new=AsyncMock(return_value="/local/home_tasks/generated.png"),
+    ):
+        await client.send_json({
+            "id": 401,
+            "type": "home_tasks/generate_task_image",
+            "todo_entity_id": "todo.ws_external",
+            "task_id": "todoist-1",
+            "entity_id": "ai_task.google_ai_task",
+            "force": True,
+        })
+        msg = await client.receive_json()
+
+    assert msg["success"] is True, msg
+    assert msg["result"]["task"]["image_url"].startswith(
+        "/local/home_tasks/generated.png?v="
+    )
+    assert len(calls) == 1
+    assert calls[0]["instructions"] == (
+        "Buy milk\n\nThe image must have a square 1:1 aspect ratio."
+    )
+    assert "PRIVATE NOTE" not in calls[0]["instructions"]
+
+    overlay_store = hass.data[DOMAIN][external_config_entry.entry_id]
+    assert overlay_store.get_overlay("todoist-1")["image_url"].startswith(
+        "/local/home_tasks/generated.png?v="
+    )
 
 
 async def test_merge_tasks_provider_owns_order_true_ignores_overlay(

--- a/tests/unit/test_overlay_store.py
+++ b/tests/unit/test_overlay_store.py
@@ -23,6 +23,7 @@ async def test_empty_overlay_returned_for_unknown_uid(hass: HomeAssistant, overl
     assert overlay["tags"] == []
     assert overlay["sub_items"] == []
     assert overlay["recurrence_enabled"] is False
+    assert overlay["image_url"] is None
 
 
 async def test_set_and_get_overlay(hass: HomeAssistant, overlay_store) -> None:
@@ -31,6 +32,23 @@ async def test_set_and_get_overlay(hass: HomeAssistant, overlay_store) -> None:
     overlay = overlay_store.get_overlay("uid-1")
     assert overlay["priority"] == 2
     assert overlay["tags"] == ["urgent"]
+
+
+async def test_image_url_is_persisted(hass: HomeAssistant, overlay_store) -> None:
+    """External tasks can keep a generated image in the local overlay."""
+    url = "/local/home_tasks/todoist-task.png?v=1"
+    await overlay_store.async_set_overlay("uid-image", image_url=url)
+    assert overlay_store.get_overlay("uid-image")["image_url"] == url
+
+
+async def test_image_url_length_is_validated(hass: HomeAssistant, overlay_store) -> None:
+    """Overlay image URLs use the same safety limit as native tasks."""
+    from custom_components.home_tasks.const import MAX_IMAGE_URL_LENGTH
+
+    with pytest.raises(ValueError, match="image_url"):
+        await overlay_store.async_set_overlay(
+            "uid-image", image_url="x" * (MAX_IMAGE_URL_LENGTH + 1)
+        )
 
 
 async def test_overlay_tags_deduplicated(hass: HomeAssistant, overlay_store) -> None:


### PR DESCRIPTION
## Summary

- expose the existing image controls for external todo columns
- persist `image_url` in the local external-task overlay without modifying the provider task
- support AI generation, media selection, removal, list/tile display, and same-title reuse
- keep generated files in the existing Home Tasks image/thumbnail pipeline and clean up orphaned local files
- avoid cross-list corruption when different providers use overlapping task IDs

Only the task title is sent to `ai_task.generate_image`; provider notes and other metadata remain local.

## Scope

This is intentionally the focused external-task parity part of #54. It does not include the later background generation queue, fuzzy/global image library, LRU policy, or calendar image resolver; those can be reviewed separately after the storage/API direction is agreed.

## Tests

- `npm test`: 165 passed
- `pytest`: 704 passed, 111 live tests deselected by the default configuration

Refs #54